### PR TITLE
Cleancodebase

### DIFF
--- a/README.md
+++ b/README.md
@@ -119,3 +119,7 @@ In order to efficiently run our integration tests, we rely on automated database
 ```
 npm run test-seedDB
 ```
+
+# Contributing
+
+When you are ready to submit a pull request from your local branch, please rebase your branch off of the shared master branch to integrate any new updates in the codebase before submitting. Any developers joining the project should feel free to review any outstanding pull requests and assign themselves to any open tickets on the Issues list. 

--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-#API Documentation 
+#API Documentation (earlier API version)
 
 https://documenter.getpostman.com/view/10112806/SWTD8H5x?version=latest
 
@@ -9,6 +9,23 @@ https://documenter.getpostman.com/view/10112806/SWTD8H5x?version=latest
 * https://youtu.be/hRv5mcxlWX8    Greenstand -  Tokens Transfer  Tutorial Video
 
 * https://youtu.be/H6levADLJ4E    Greenstand - Permission Access Tutorial Video
+
+# Getting Started
+
+## Project Setup
+
+Open terminal and navigate to a folder to install this project:
+
+```
+git clone https://github.com/Greenstand/treetracker-token-trading-api.git
+
+```
+Install all necessary dependencies: 
+
+```
+npm install
+
+```
 
 # How to test
 

--- a/__tests__/seed.js
+++ b/__tests__/seed.js
@@ -104,26 +104,25 @@ async function seed() {
   // }
 
   //entity role
-  // {
-  //   log.debug('clear role');
-  //   await knex('entity_role')
-  //     .insert([{
-  //       entity_id: entity.id,
-  //       role_name: 'list_trees',
-  //       enabled: true,
-  //     },{
-  //       entity_id: entity.id,
-  //       role_name: 'manage_accounts',
-  //       enabled: true,
-  //     },{
-  //       entity_id: entity.id,
-  //       role_name: 'accounts',
-  //       enabled: true,
-  //     }]);
-  // }
+  log.debug('clear role');
+  await knex('entity_role')
+    .insert([{
+      entity_id: wallet.id,
+      role_name: 'list_trees',
+      enabled: true,
+    },{
+      entity_id: wallet.id,
+      role_name: 'manage_accounts',
+      enabled: true,
+    },{
+      entity_id: wallet.id,
+      role_name: 'accounts',
+      enabled: true,
+    }]);
+
 
   //tree
-  await knex('public.trees')
+  await knex('trees')
     .insert({
       id: tree.id,
       time_created: new Date(),
@@ -132,16 +131,14 @@ async function seed() {
 
 
   // //token
-  {
-    log.log('seed token');
-    await knex('wallets.token')
-      .insert({
-        id: token.id,
-        tree_id: tree.id,
-        entity_id: wallet.id,
-        uuid: token.uuid,
-      });
-  }
+  log.log('seed token');
+  await knex('wallets.token')
+    .insert({
+      id: token.id,
+      tree_id: tree.id,
+      entity_id: wallet.id,
+      uuid: token.uuid,
+    });
 }
 
 async function clear() {
@@ -155,22 +152,10 @@ async function clear() {
   await knex('token').del();
   log.debug('clear all trees');
   await knex('trees').del();
-  // log.debug('clear all token');
-  // await knex('wallets.token').del();
-  // log.debug('clear all locations');
-  // await knex('locations').del();
-  // log.debug('clear all pending_updates');
-  // await knex('pending_update').del();
-  // log.debug('clear all notes');
-  // await knex('notes').del();
-  // log.debug('clear all planter');
-  // await knex('public.planter').del();
-  // log.debug('clear all entity_role');
-  // await knex('public.entity_role').del();
-  // log.debug('clear all entity_manager');
-  // await knex('public.entity_manager').del();
   log.debug('clear all wallets');
   await knex('wallets.wallet').del();
+  log.debug('clear all entity_trust');
+  await knex('wallets.entity_trust').del();
 }
 
 module.exports = {seed, clear, apiKey, wallet, tree, token};

--- a/__tests__/seed.js
+++ b/__tests__/seed.js
@@ -13,20 +13,24 @@ const knex = require('knex')({
 });
 
 
-
-
-
-
 const apiKey = 'FORTESTFORTESTFORTESTFORTESTFORTEST';
-const entity = {
+const wallet = {
   id: 10,
   name: 'fortest',
-  wallet: 'fortest',
   password: 'test1234',
   passwordHash: '31dd4fe716e1a908f0e9612c1a0e92bfdd9f66e75ae12244b4ee8309d5b869d435182f5848b67177aa17a05f9306e23c10ba41675933e2cb20c66f1b009570c1',
   salt: 'TnDe2LDPS7VaPD9GQWL3fhG4jk194nde',
   type: 'p',
 };
+// const entity = {
+//   id: 10,
+//   name: 'fortest',
+//   wallet: 'fortest',
+//   password: 'test1234',
+//   passwordHash: '31dd4fe716e1a908f0e9612c1a0e92bfdd9f66e75ae12244b4ee8309d5b869d435182f5848b67177aa17a05f9306e23c10ba41675933e2cb20c66f1b009570c1',
+//   salt: 'TnDe2LDPS7VaPD9GQWL3fhG4jk194nde',
+//   type: 'p',
+// };
 
 const tree = {
   id: 999999,
@@ -39,20 +43,20 @@ const token = {
 
 const storyOfThisSeed = `
     api_key: ${apiKey}
-    a entity: #${entity.id}
-      type: ${entity.type}
-      name: ${entity.name}
-      wallet: ${entity.wallet}
-      password: ${entity.password}
+    a wallet: #${wallet.id}
+      type: ${wallet.type}
+      name: ${wallet.name}
+      wallet: ${wallet.wallet}
+      password: ${wallet.password}
 
     a tree: #${tree.id}
 
     a token: #${token.id}
       tree: #${tree.id}
-      entity: #${entity.id}
+      wallet: #${wallet.id}
       uuid: ${token.uuid}
 
-    entity #${entity.id} planted a tree #${tree.id}, get a token #${token.id}
+    wallet #${wallet.id} planted a tree #${tree.id}, get a token #${token.id}
 `;
 console.debug(
 '--------------------------story of database ----------------------------------',
@@ -60,11 +64,10 @@ storyOfThisSeed,
 '-----------------------------------------------------------------------------',
 );
 
-async function seed(){
-
+async function seed() {
   log.debug('seed api key');
-  //TODO should use appropriate hash & salt to populate this talbel
-  await knex('api_key')
+  //TODO should use appropriate hash & salt to populate this table
+  await knex('wallets.api_key')
     .insert({
       key: apiKey,
       tree_token_api_access: true,
@@ -73,81 +76,101 @@ async function seed(){
       name: 'test',
     });
 
-  //entity
-  {
-    await knex('entity')
-      .where('id', entity.id)
-      .del();
-    await knex('entity')
-      .insert({
-        id: entity.id,
-        type: entity.type,
-        name: entity.name,
-        wallet: entity.wallet,
-        password: entity.passwordHash,
-        salt: entity.salt,
-      });
-  }
+  // wallet
+  await knex('wallets.wallet')
+    .insert({
+      id: wallet.id,
+      type: wallet.type,
+      name: wallet.name,
+      password: wallet.passwordHash,
+      salt: wallet.salt,
+    });
+
+
+  // //entity
+  // {
+  //   await knex('entity')
+  //     .where('id', entity.id)
+  //     .del();
+  //   await knex('entity')
+  //     .insert({
+  //       id: entity.id,
+  //       type: entity.type,
+  //       name: entity.name,
+  //       wallet: entity.wallet,
+  //       password: entity.passwordHash,
+  //       salt: entity.salt,
+  //     });
+  // }
 
   //entity role
-  {
-    log.debug('clear role');
-    await knex('entity_role')
-      .insert([{
-        entity_id: entity.id,
-        role_name: 'list_trees',
-        enabled: true,
-      },{
-        entity_id: entity.id,
-        role_name: 'manage_accounts',
-        enabled: true,
-      },{
-        entity_id: entity.id,
-        role_name: 'accounts',
-        enabled: true,
-      }]);
-  }
+  // {
+  //   log.debug('clear role');
+  //   await knex('entity_role')
+  //     .insert([{
+  //       entity_id: entity.id,
+  //       role_name: 'list_trees',
+  //       enabled: true,
+  //     },{
+  //       entity_id: entity.id,
+  //       role_name: 'manage_accounts',
+  //       enabled: true,
+  //     },{
+  //       entity_id: entity.id,
+  //       role_name: 'accounts',
+  //       enabled: true,
+  //     }]);
+  // }
 
   //tree
-  {
-    await knex('trees')
-      .insert({
-        id: tree.id,
-        time_created: new Date(),
-        time_updated: new Date(),
-      });
-  }
+  await knex('public.trees')
+    .insert({
+      id: tree.id,
+      time_created: new Date(),
+      time_updated: new Date(),
+    });
 
-  //token
+
+  // //token
   {
     log.log('seed token');
-    await knex('token')
+    await knex('wallets.token')
       .insert({
         id: token.id,
         tree_id: tree.id,
-        entity_id: entity.id,
+        entity_id: wallet.id,
         uuid: token.uuid,
       });
   }
 }
 
-async function clear(){
-  log.debug('clear all key');
-  await knex('api_key').del();
+async function clear() {
+  log.debug('clear all api keys');
+  await knex('wallets.api_key').del();
   log.debug('clear all transaction');
   await knex('wallets.transaction').del();
-  log.debug('clear all token');
+  await knex('transaction').del();
+  log.debug('clear all tokens');
+  await knex('wallets.token').del();
   await knex('token').del();
   log.debug('clear all trees');
   await knex('trees').del();
-  log.debug('clear all planter');
-  await knex('planter').del();
-  log.debug('clear all entity_role');
-  await knex('entity_role').del();
-  log.debug('clear all entity_manager');
-  await knex('entity_manager').del();
-  log.debug('clear all entity');
-  await knex('entity').del();
+  // log.debug('clear all token');
+  // await knex('wallets.token').del();
+  // log.debug('clear all locations');
+  // await knex('locations').del();
+  // log.debug('clear all pending_updates');
+  // await knex('pending_update').del();
+  // log.debug('clear all notes');
+  // await knex('notes').del();
+  // log.debug('clear all planter');
+  // await knex('public.planter').del();
+  // log.debug('clear all entity_role');
+  // await knex('public.entity_role').del();
+  // log.debug('clear all entity_manager');
+  // await knex('public.entity_manager').del();
+  log.debug('clear all wallets');
+  await knex('wallets.wallet').del();
 }
 
-module.exports = {seed, clear, apiKey, entity, tree, token};
+module.exports = {seed, clear, apiKey, wallet, tree, token};

--- a/__tests__/seed.js
+++ b/__tests__/seed.js
@@ -156,6 +156,9 @@ async function clear() {
   await knex('wallets.wallet').del();
   log.debug('clear all entity_trust');
   await knex('wallets.entity_trust').del();
+  log.debug('clear entity_roles');
+  await knex('entity_role').del();
+
 }
 
 module.exports = {seed, clear, apiKey, wallet, tree, token};

--- a/__tests__/seed.js
+++ b/__tests__/seed.js
@@ -89,9 +89,6 @@ async function seed() {
 
   //entity
   await knex('entity')
-    .where('id', wallet.id)
-    .del();
-  await knex('entity')
     .insert({
       id: wallet.id,
       type: wallet.type,
@@ -145,10 +142,8 @@ async function clear() {
   await knex('wallets.api_key').del();
   log.debug('clear all transaction');
   await knex('wallets.transaction').del();
-  await knex('transaction').del();
   log.debug('clear all tokens');
   await knex('wallets.token').del();
-  await knex('token').del();
   log.debug('clear all trees');
   await knex('trees').del();
   log.debug('clear all wallets');
@@ -159,7 +154,6 @@ async function clear() {
   await knex('entity_role').del();
   log.debug('clear entities');
   await knex('entity').del();
-
 }
 
 module.exports = {seed, clear, apiKey, wallet, tree, token};

--- a/__tests__/seed.js
+++ b/__tests__/seed.js
@@ -87,24 +87,23 @@ async function seed() {
     });
 
 
-  // //entity
-  // {
-  //   await knex('entity')
-  //     .where('id', entity.id)
-  //     .del();
-  //   await knex('entity')
-  //     .insert({
-  //       id: entity.id,
-  //       type: entity.type,
-  //       name: entity.name,
-  //       wallet: entity.wallet,
-  //       password: entity.passwordHash,
-  //       salt: entity.salt,
-  //     });
-  // }
+  //entity
+  await knex('entity')
+    .where('id', wallet.id)
+    .del();
+  await knex('entity')
+    .insert({
+      id: wallet.id,
+      type: wallet.type,
+      name: wallet.name,
+      wallet: wallet.name,
+      password: wallet.passwordHash,
+      salt: wallet.salt,
+    });
+
 
   //entity role
-  log.debug('clear role');
+  log.debug('insert role');
   await knex('entity_role')
     .insert([{
       entity_id: wallet.id,
@@ -130,7 +129,7 @@ async function seed() {
     });
 
 
-  // //token
+  // token
   log.log('seed token');
   await knex('wallets.token')
     .insert({
@@ -158,6 +157,8 @@ async function clear() {
   await knex('wallets.entity_trust').del();
   log.debug('clear entity_roles');
   await knex('entity_role').del();
+  log.debug('clear entities');
+  await knex('entity').del();
 
 }
 

--- a/__tests__/seed.spec.js
+++ b/__tests__/seed.spec.js
@@ -43,18 +43,18 @@ describe("Seed data into DB", () => {
         .to.equal(seed.tree.id);
       expect(token)
         .to.have.property('entity_id')
-        .to.equal(seed.entity.id);
+        .to.equal(seed.wallet.id);
     });
 
   });
 
 
-  describe(`Should have the entity ${seed.entity.id}`, () => {
+  describe(`Should have the entity ${seed.wallet.id}`, () => {
     let r;
 
     before(async () => {
       r = await pool.query(
-        `select * from entity where wallet = '${seed.entity.wallet}'`
+        `select * from entity where wallet = '${seed.wallet.name}'`
       )
       expect(r)
         .to.have.property('rows').to.have.lengthOf(1);
@@ -77,7 +77,7 @@ describe("Seed data into DB", () => {
 
     it("Should be able to check the password", () => {
       expect(seed)
-        .to.have.property('entity')
+        .to.have.property('wallet')
         .to.have.property('password')
         .to.be.a('string');
       expect(r)
@@ -85,17 +85,17 @@ describe("Seed data into DB", () => {
         .to.have.property(0)
         .to.have.property("salt")
         .to.be.a("string");
-      const hash = sha512(seed.entity.password, r.rows[0].salt);
+      const hash = sha512(seed.wallet.password, r.rows[0].salt);
       expect(r.rows[0])
         .to.have.property('password')
-        .to.equal(seed.entity.passwordHash);
+        .to.equal(seed.wallet.passwordHash);
     });
 
     it("Should have permission list_trees", async () => {
       const query = 
         `SELECT *
           FROM entity_role
-          WHERE entity_id = ${seed.entity.id}
+          WHERE entity_id = ${seed.wallet.id}
           AND role_name = 'list_trees'
           AND enabled = TRUE`;
       const result = await pool.query(query);
@@ -109,7 +109,7 @@ describe("Seed data into DB", () => {
       const query = 
         `SELECT *
           FROM entity_role
-          WHERE entity_id = ${seed.entity.id}
+          WHERE entity_id = ${seed.wallet.id}
           AND role_name = 'accounts'
           AND enabled = TRUE`;
       const result = await pool.query(query);

--- a/__tests__/supertest.js
+++ b/__tests__/supertest.js
@@ -25,7 +25,7 @@ const newWallet = {
 
 const apiKey = seed.apiKey;
 
-describe(`Route integration, login [POST /auth] with wallet:${seed.wallet.name} `, () => {
+describe('Route integration', () => {
   let token;
 
   beforeEach(async () => {
@@ -80,8 +80,6 @@ describe(`Route integration, login [POST /auth] with wallet:${seed.wallet.name} 
       .which.have.property('token', seed.token.uuid);
   });
 
-
-
   describe(`wallet:${seed.wallet.name} request trust relationship with type: send`, () => {
 
     describe("Request the send-trust-relationship", () => {
@@ -99,6 +97,7 @@ describe(`Route integration, login [POST /auth] with wallet:${seed.wallet.name} 
       });
 
       it("Then, some one accept the request; Then we can get the trust", () => {
+
       });
 
     });
@@ -107,17 +106,28 @@ describe(`Route integration, login [POST /auth] with wallet:${seed.wallet.name} 
 
   describe("Relationship", () => {
 
+    beforeEach(async () => {
+      const res = await request(server)
+        .post("/trust_relationships")
+        .set('treetracker-api-key', apiKey)
+        .set('Authorization', `Bearer ${token}`)
+        .send({
+          trust_request_type: 'send',
+          wallet: seed.wallet.name,
+        });
+      expect(res).property("statusCode").to.eq(200);
+    });
     it("GET /trust_relationships", async () => {
       const res = await request(server)
         .get("/trust_relationships")
         .set('treetracker-api-key', apiKey)
         .set('Authorization', `Bearer ${token}`);
       expect(res).property("statusCode").to.eq(200);
+      log.debug(res);
       expect(res).property("body").property("trust_relationships").lengthOf(1);
       console.warn("body:" , res.body.trust_relationships);
       expect(res.body.trust_relationships[0]).property("id").a("number");
     });
-
 
     describe("Request trust relationship", () => {
       it("POST /trust_relationships with wrong request type", async () => {
@@ -139,7 +149,7 @@ describe(`Route integration, login [POST /auth] with wallet:${seed.wallet.name} 
           .set('Authorization', `Bearer ${token}`)
           .send({
             trust_request_type: 'send',
-            wallet: 'Zaven',
+            wallet: seed.wallet.name,
           });
         expect(res).property("statusCode").to.eq(200);
       });

--- a/__tests__/supertest.js
+++ b/__tests__/supertest.js
@@ -68,7 +68,7 @@ describe('Route integration', () => {
 
   // Tests that require logged-in authorization
 
-  it(`[GET /token/${seed.token.uuid}] Should be able to get a token `, async () => {
+  it(`[GET /token/${seed.token.uuid}] Should be able to get a token `, async (done) => {
     const res = await request(server)
       .get(`/token/${seed.token.uuid}`)
       .set('treetracker-api-key', apiKey)
@@ -78,6 +78,7 @@ describe('Route integration', () => {
       .that.have.lengthOf(1)
       .that.have.property(0)
       .which.have.property('token', seed.token.uuid);
+    done();
   });
 
   describe(`wallet:${seed.wallet.name} request trust relationship with type: send`, () => {

--- a/__tests__/supertest.js
+++ b/__tests__/supertest.js
@@ -15,17 +15,17 @@ const log = require('loglevel');
 log.setLevel('warn');
 
 const mockUser = {
-  wallet: seed.entity.wallet,
-  password: seed.entity.password,
+  wallet: seed.wallet.name,
+  password: seed.wallet.password,
 };
 
-const subWallet = {
+const newWallet = {
   name: 'MyFriendsNewWallet',
 };
 
 const apiKey = seed.apiKey;
 
-describe(`Route integration, login [POST /auth] with wallet:${seed.entity.wallet} `, () => {
+describe(`Route integration, login [POST /auth] with wallet:${seed.wallet.name} `, () => {
   let token;
 
   beforeEach(async () => {
@@ -52,7 +52,7 @@ describe(`Route integration, login [POST /auth] with wallet:${seed.entity.wallet
   });
 
   // Authorization path
-  it(`[POST /auth] login with wallet:${seed.entity.wallet}`, (done) => {
+  it(`[POST /auth] login with wallet:${seed.wallet.name}`, (done) => {
     request(server)
       .post('/auth')
       .set('treetracker-api-key', apiKey)
@@ -66,6 +66,8 @@ describe(`Route integration, login [POST /auth] with wallet:${seed.entity.wallet
       });
   });
 
+  // Tests that require logged-in authorization
+
   it(`[GET /token/${seed.token.uuid}] Should be able to get a token `, async () => {
     const res = await request(server)
       .get(`/token/${seed.token.uuid}`)
@@ -78,12 +80,153 @@ describe(`Route integration, login [POST /auth] with wallet:${seed.entity.wallet
       .which.have.property('token', seed.token.uuid);
   });
 
-  // Tests that require logged-in authorization
+
+
+  describe(`wallet:${seed.wallet.name} request trust relationship with type: send`, () => {
+
+    describe("Request the send-trust-relationship", () => {
+
+      beforeEach(async () => {
+        const res = await request(server)
+          .post("/trust_relationships")
+          .set('treetracker-api-key', apiKey)
+          .set('Authorization', `Bearer ${token}`)
+          .send({
+            trust_request_type: 'send',
+            wallet: seed.wallet.name,
+          });
+        expect(res).property("statusCode").to.eq(200);
+      });
+
+      it("Then, some one accept the request; Then we can get the trust", () => {
+      });
+
+    });
+
+  });
+
+  describe("Relationship", () => {
+
+    it("GET /trust_relationships", async () => {
+      const res = await request(server)
+        .get("/trust_relationships")
+        .set('treetracker-api-key', apiKey)
+        .set('Authorization', `Bearer ${token}`);
+      expect(res).property("statusCode").to.eq(200);
+      expect(res).property("body").property("trust_relationships").lengthOf(1);
+      console.warn("body:" , res.body.trust_relationships);
+      expect(res.body.trust_relationships[0]).property("id").a("number");
+    });
+
+
+    describe("Request trust relationship", () => {
+      it("POST /trust_relationships with wrong request type", async () => {
+        const res = await request(server)
+          .post("/trust_relationships")
+          .set('treetracker-api-key', apiKey)
+          .set('Authorization', `Bearer ${token}`)
+          .send({
+            trust_request_type: 'wrongtype',
+            wallet: 'any',
+          });
+        expect(res).property("statusCode").to.eq(400);
+      });
+
+      it("POST /trust_relationships", async () => {
+        const res = await request(server)
+          .post("/trust_relationships")
+          .set('treetracker-api-key', apiKey)
+          .set('Authorization', `Bearer ${token}`)
+          .send({
+            trust_request_type: 'send',
+            wallet: 'Zaven',
+          });
+        expect(res).property("statusCode").to.eq(200);
+      });
+    });
+  });
+
+});
+
+/* __________________________OLD TESTS FOR PREVIOUS API VERSION___________________________
+
+  xdescribe(`[POST /transfer] Now transfer wallet:${seed.wallet.name}'s token to the new wallet`, () => {
+
+    beforeEach(async () => {
+      const res = await request(server)
+        .post('/transfer')
+        .set('treetracker-api-key', apiKey)
+        .set('Authorization', `Bearer ${token}`)
+        .send({
+          tokens: [seed.token.uuid],
+          sender_wallet: seed.wallet.name,
+          receiver_wallet: newWallet.name,
+        });
+      expect(res)
+        .to.have.property('statusCode', 200);
+    });
+
+    xit('[GET /history] Should be able to find a record about this token in the history API', async () => {
+      const res = await request(server)
+        .get(`/history?token=${seed.token.uuid}`)
+        .set('treetracker-api-key', apiKey)
+        .set('Authorization', `Bearer ${token}`);
+      expect(res)
+        .to.have.property('statusCode', 200);
+      expect(res.body)
+        .to.have.property('history')
+        .to.have.lengthOf(1);
+      expect(res.body.history[0])
+        .to.have.property('token', seed.token.uuid);
+      expect(res.body.history[0])
+        .to.have.property('sender_wallet', seed.wallet.name);
+      expect(res.body.history[0])
+        .to.have.property('receiver_wallet', newWallet.name);
+    });
+
+  });
+
+  describe(`[POST /send] Now transfer wallet:${seed.wallet.name}'s token to the new wallet`, () => {
+
+    beforeEach(async () => {
+      const res = await request(server)
+        .post('/send')
+        .set('treetracker-api-key', apiKey)
+        .set('Authorization', `Bearer ${token}`)
+        .send({
+          tokens: [seed.token.uuid],
+          receiver_wallet: newWallet.name,
+        });
+      expect(res)
+        .to.have.property('statusCode', 200);
+    });
+
+    xit('[GET /history] Should be able to find a record about this token in the history API', async () => {
+      const res = await request(server)
+        .get(`/history?token=${seed.token.uuid}`)
+        .set('treetracker-api-key', apiKey)
+        .set('Authorization', `Bearer ${token}`);
+      expect(res)
+        .to.have.property('statusCode', 200);
+      expect(res.body)
+        .to.have.property('history')
+        .to.have.lengthOf(1);
+      expect(res.body.history[0])
+        .to.have.property('token', seed.token.uuid);
+      expect(res.body.history[0])
+        .to.have.property('sender_wallet', seed.wallet.name);
+      expect(res.body.history[0])
+        .to.have.property('receiver_wallet', newWallet.name);
+    });
+
+  });
+
+});
 
   // Get trees in user's wallet
   describe('[GET /tree] gets trees from logged in user wallet', () => {
 
-    it(`Should have 1 tree under the wallet:${seed.entity.wallet}`, (done) => {
+    xit(`Should have 1 tree under the wallet:${seed.entity.wallet}`, (done) => {
       request(server)
         .get('/tree')
         .set('treetracker-api-key', apiKey)
@@ -103,8 +246,8 @@ describe(`Route integration, login [POST /auth] with wallet:${seed.entity.wallet
     });
   });
 
-// Get details of logged in account and sub-accounts
-  it(`[GET /account] get account should find the current wallet ${seed.entity.wallet}`, async () => {
+  // Get details of logged in account
+  xit(`[GET /wallet] get account should find the current wallet ${seed.wallet.name}`, async () => {
     expect(token)
       .to.match(/\S+/);
     let response = await request(server)
@@ -119,25 +262,26 @@ describe(`Route integration, login [POST /auth] with wallet:${seed.entity.wallet
     expect(response.body)
       .to.have.property('accounts')
       .that.have.property(0)
-      .that.to.have.property('wallet', seed.entity.wallet);
+      .that.to.have.property('wallet', seed.wallet.name);
   });
 
-
-  describe(`[POST /account] Create subWallet '${subWallet.name}' under wallet:${seed.entity.wallet}`, () => {
+  describe(`[POST /wallet] Create subWallet '${newWallet.name}`, () => {
 
     beforeEach(async () => {
       const res = await request(server)
-        .post('/account')
+        .post('/wallets')
         .set('treetracker-api-key', apiKey)
         .set('Authorization', `Bearer ${token}`)
         .send({
-          wallet: subWallet.name,
+          wallet: newWallet.name,
         });
       expect(res)
         .to.have.property('statusCode', 200);
     });
 
-    it('[GET /account] Should find two accounts now', async () => {
+
+
+    xit('[GET /wallets] Should find two accounts now', async () => {
       const res = await request(server)
         .get('/account')
         .set('treetracker-api-key', apiKey)
@@ -152,41 +296,10 @@ describe(`Route integration, login [POST /auth] with wallet:${seed.entity.wallet
         .to.have.property('wallet', subWallet.name);
     });
 
-    describe(`[POST /transfer] Now transfer wallet:${seed.entity.wallet}'s token to the new wallet`, () => {
 
-      beforeEach(async () => {
-        const res = await request(server)
-          .post('/transfer')
-          .set('treetracker-api-key', apiKey)
-          .set('Authorization', `Bearer ${token}`)
-          .send({
-            tokens: [seed.token.uuid],
-            sender_wallet: seed.entity.wallet,
-            receiver_wallet: subWallet.name,
-          });
-        expect(res)
-          .to.have.property('statusCode', 200);
-      });
 
-      it('[GET /history] Should be able to find a record about this token in the history API', async () => {
-        const res = await request(server)
-          .get(`/history?token=${seed.token.uuid}`)
-          .set('treetracker-api-key', apiKey)
-          .set('Authorization', `Bearer ${token}`);
-        expect(res)
-          .to.have.property('statusCode', 200);
-        expect(res.body)
-          .to.have.property('history')
-          .to.have.lengthOf(1);
-        expect(res.body.history[0])
-          .to.have.property('token', seed.token.uuid);
-        expect(res.body.history[0])
-          .to.have.property('sender_wallet', seed.entity.wallet);
-        expect(res.body.history[0])
-          .to.have.property('receiver_wallet', subWallet.name);
-      });
 
-    });
+
 
     describe(`[POST /transfer/bundle] Now bundle transfer wallet:${seed.entity.wallet}'s token to the new wallet`, () => {
 
@@ -204,7 +317,7 @@ describe(`Route integration, login [POST /auth] with wallet:${seed.entity.wallet
           .to.have.property('statusCode', 200);
       });
 
-      it('[GET /history] Should be able to find a record about this token in the history API', async () => {
+      xit('[GET /history] Should be able to find a record about this token in the history API', async () => {
         const res = await request(server)
           .get(`/history?token=${seed.token.uuid}`)
           .set('treetracker-api-key', apiKey)
@@ -224,136 +337,5 @@ describe(`Route integration, login [POST /auth] with wallet:${seed.entity.wallet
 
     });
 
-    describe(`[POST /send] Now transfer wallet:${seed.entity.wallet}'s token to the new wallet`, () => {
-
-      beforeEach(async () => {
-        const res = await request(server)
-          .post('/send')
-          .set('treetracker-api-key', apiKey)
-          .set('Authorization', `Bearer ${token}`)
-          .send({
-            tokens: [seed.token.uuid],
-            receiver_wallet: subWallet.name,
-          });
-        expect(res)
-          .to.have.property('statusCode', 200);
-      });
-
-      it('[GET /history] Should be able to find a record about this token in the history API', async () => {
-        const res = await request(server)
-          .get(`/history?token=${seed.token.uuid}`)
-          .set('treetracker-api-key', apiKey)
-          .set('Authorization', `Bearer ${token}`);
-        expect(res)
-          .to.have.property('statusCode', 200);
-        expect(res.body)
-          .to.have.property('history')
-          .to.have.lengthOf(1);
-        expect(res.body.history[0])
-          .to.have.property('token', seed.token.uuid);
-        expect(res.body.history[0])
-          .to.have.property('sender_wallet', seed.entity.wallet);
-        expect(res.body.history[0])
-          .to.have.property('receiver_wallet', subWallet.name);
-      });
-
-    });
-
-  });
-
-  /*
-  Create a new managed sub-wallet for logged in account
-
-  Don't have an endpoint that handles deletion yet so will only use this test once we have
-  that and can undo action in the database
-
-    describe('/account', () => {
-      describe('POST', () => {
-        it('creates new sub-wallet', (done) => {
-          request(server)
-            .post('/account')
-            .set('treetracker-api-key', apiKey)
-            .set('Authorization', `Bearer ${token}`)
-            .send(mockWallet)
-            .expect(200)
-            .expect('Content-Type', /application\/json/)
-            .end((err, res) => {
-              if (err) done(err);
-              expect(res.body).to.have.property('wallet');
-              assert(res.body.wallet === 'mockwallet', 'checks name of sub-wallet');
-            });
-        });
-      });
-    });
-
-  */
-
-  describe(`wallet:${seed.entity.wallet} request trust relationship with type: send`, () => {
-
-    describe("Request the send-trust-relationship", () => {
-
-      beforeEach(async () => {
-        const res = await request(server)
-          .post("/trust_relationships")
-          .set('treetracker-api-key', apiKey)
-          .set('Authorization', `Bearer ${token}`)
-          .send({
-            trust_request_type: 'send',
-            wallet: seed.entity.wallet,
-          });
-        expect(res).property("statusCode").to.eq(200);
-      });
-
-      it("Then, some one accept the request; Then we can get the trust", () => {
-      });
-
-    });
-
-  });
-
-//  describe("Relationship", () => {
-//
-//    it("GET /trust_relationships", async () => {
-//      const res = await request(server)
-//        .get("/trust_relationships")
-//        .set('treetracker-api-key', apiKey)
-//        .set('Authorization', `Bearer ${token}`);
-//      expect(res).property("statusCode").to.eq(200);
-//      expect(res).property("body").property("trust_relationships").lengthOf(1);
-//      console.warn("body:" , res.body.trust_relationships);
-//      expect(res.body.trust_relationships[0]).property("id").a("number");
-//    });
-//
-//
-//    describe("Request trust relationship", () => {
-//      it("POST /trust_relationships with wrong request type", async () => {
-//        const res = await request(server)
-//          .post("/trust_relationships")
-//          .set('treetracker-api-key', apiKey)
-//          .set('Authorization', `Bearer ${token}`)
-//          .send({
-//            trust_request_type: 'wrongtype',
-//            wallet: 'any',
-//          });
-//        expect(res).property("statusCode").to.eq(400);
-//      });
-//
-//
-//
-//      it("POST /trust_relationships", async () => {
-//        const res = await request(server)
-//          .post("/trust_relationships")
-//          .set('treetracker-api-key', apiKey)
-//          .set('Authorization', `Bearer ${token}`)
-//          .send({
-//            trust_request_type: 'send',
-//            wallet: 'Zaven',
-//          });
-//        expect(res).property("statusCode").to.eq(200);
-//      });
-//    });
-//
-//  });
-
-});
+*/
 

--- a/database/migrations/20200902014751-CreateTableEntity-Trust.js
+++ b/database/migrations/20200902014751-CreateTableEntity-Trust.js
@@ -17,12 +17,12 @@ exports.setup = function(options, seedLink) {
 exports.up = function(db) {
   return db.createTable('entity_trust', {
     id: { type: 'int', primaryKey: true, autoIncrement: true },
-    actor_entity_id: { type: 'int', notNull: true },
+    actor_entity_id: { type: 'int' },
     target_entity_id: { type: 'int', notNull: true },
-    type: { type: 'entity_trust_type', notNull: true },
-    originator_entity_id: { type: 'int', notNull: true },
+    type: { type: 'entity_trust_type' },
+    originator_entity_id: { type: 'int' },
     request_type: { type: 'entity_trust_request_type', notNull: true },
-    state: { type: 'entity_trust_state_type', notNull: true },
+    state: { type: 'entity_trust_state_type' },
     created_at: { 
       type: 'timestamp',
       notNull: true,
@@ -33,7 +33,7 @@ exports.up = function(db) {
       notNull: true,
       defaultValue: new String('now()')
     },
-    active: { type: 'boolean', notNull: true },
+    active: { type: 'boolean' },
   });
 };
 

--- a/package.json
+++ b/package.json
@@ -11,7 +11,7 @@
     "serverTest": "cd ./server && DEBUG=loopback:*,express:* nodemon server.js",
     "server": "cd ./server && nodemon server.js",
     "test-seedDB": "NODE_ENV=test mocha --timeout 10000 --require co-mocha './**/*.spec.js'",
-    "test-integration": "NODE_ENV=test mocha --timeout 10000 --require co-mocha './__tests__/supertest.js'"
+    "test-integration": "NODE_ENV=test mocha --timeout 20000 --require co-mocha './__tests__/supertest.js'"
   },
   "keywords": [],
   "author": "",

--- a/server/app.js
+++ b/server/app.js
@@ -41,7 +41,7 @@ app.post('/wallet/:wallet_id/trust/request', asyncHandler(async (req, res, next)
 
 }));
 
-app.post('/wallet/:wallet_id/trust/approve',  asyncHandler(async (req, res, next) => {
+app.post('/wallet/:wallet_id/trust/approve', asyncHandler(async (req, res, next) => {
 
   const type = req.body.type;
   //const wallet_id = req.body.wallet_id; // in the bearer token

--- a/server/app.js
+++ b/server/app.js
@@ -51,11 +51,11 @@ app.post('/wallet/:wallet_id/trust/approve', asyncHandler(async (req, res, next)
 
 // Global error handler
 app.use((err, req, res, next) => {
-  console.warn("cathed the error:", err);
-  if(err instanceof HttpError){
+  console.warn("caught the error:", err);
+  if (err instanceof HttpError) {
     res.status(err.code).send(err.message);
-  }else{
-    res.status(500).send("Unknown error");
+  } else {
+    res.status(err.status).send(err.message.err);
   }
 });
 

--- a/server/controllers/authController.js
+++ b/server/controllers/authController.js
@@ -186,7 +186,7 @@ authController.checkAccess = (role) => {
     const walletId = res.locals.wallet_id;
     const query = {
       text: `SELECT *
-      FROM entity_role
+      FROM public.entity_role
       WHERE entity_id = $1
       AND role_name = $2
       AND enabled = TRUE`,
@@ -196,7 +196,7 @@ authController.checkAccess = (role) => {
 
     if (rval.rows.length !== 1) {
       log.debug("check access fail...", walletId, role);
-      next({
+      return next({
         log: `ERROR: Permission for ${role} not granted`,
         status: 401,
         message: { err: `ERROR: Permission to ${role} not granted`},

--- a/server/controllers/authController.js
+++ b/server/controllers/authController.js
@@ -10,8 +10,8 @@ log.setLevel("debug");
 
 // PRIVATE and PUBLIC key
 console.warn("__dirname:", __dirname);
-const privateKEY = FS.readFileSync(path.resolve(__dirname, '../../config/private.key'), 'utf8');
-const publicKEY = FS.readFileSync(path.resolve(__dirname, '../../config/public.key'), 'utf8');
+const privateKEY = FS.readFileSync(path.resolve(__dirname, '../../config/jwtRS256.key'), 'utf8');
+const publicKEY = FS.readFileSync(path.resolve(__dirname, '../../config/jwtRS256.key.pub'), 'utf8');
 
 const signingOptions = {
   issuer: "greenstand",
@@ -63,7 +63,7 @@ authController.apiKey = async (req, res, next) => {
       message: { err: 'Invalid API access' },
     });
   }
-  console.log('Valid Access');
+  // console.log('Valid Access');
   next();
 };
 
@@ -96,12 +96,12 @@ authController.authorize = async (req, res, next) => {
   // Now check for wallet/password
   const query2 = {
     text: `SELECT *
-    FROM entity
-    WHERE wallet = $1
+    FROM wallet
+    WHERE name = $1
     AND password IS NOT NULL`,
     values: [wallet],
   };
-  console.log(query2);
+  // console.log(query2);
   const rval2 = await pool.query(query2);
 
   if (rval2.rows.length === 0) {
@@ -113,10 +113,10 @@ authController.authorize = async (req, res, next) => {
     });
   }
 
-  const entity = rval2.rows[0];
-  const hash = sha512(password, entity.salt);
+  const wallets = rval2.rows[0];
+  const hash = sha512(password, wallets.salt);
 
-  if (hash !== entity.password) {
+  if (hash !== wallets.password) {
     console.log('ERROR: Authentication, invalid credentials.');
     next({
       log: 'Error: Invalid credentials',
@@ -124,7 +124,7 @@ authController.authorize = async (req, res, next) => {
       message: { err: 'Error: Invalid credentials' },
     });
   }
-  res.locals.id = entity.id;
+  res.locals.id = wallets.id;
   next();
 };
 
@@ -170,7 +170,7 @@ authController.verifyJWT = (req, res, next) => {
           message: { err: 'ERROR: Authentication, token not verified' },
         });
       }
-      res.locals.entity_id = decod.id;
+      res.locals.wallet_id = decod.id;
     });
   }
   next();
@@ -183,19 +183,19 @@ authController.verifyJWT = (req, res, next) => {
 
 authController.checkAccess = (role) => {
     return async (req, res, next) => {
-    const entityId = res.locals.entity_id;
+    const walletId = res.locals.wallet_id;
     const query = {
       text: `SELECT *
       FROM entity_role
       WHERE entity_id = $1
       AND role_name = $2
       AND enabled = TRUE`,
-      values: [entityId, role]
+      values: [walletId, role]
     };
     const rval = await pool.query(query);
 
     if (rval.rows.length !== 1) {
-      log.debug("check access fail...", entityId, role);
+      log.debug("check access fail...", walletId, role);
       next({
         log: `ERROR: Permission for ${role} not granted`,
         status: 401,

--- a/server/controllers/trustController.js
+++ b/server/controllers/trustController.js
@@ -21,7 +21,7 @@ function asyncUtilWrap(...args) {
 trustController.get = async (req, res, next) => {
   const trustModel = new TrustModel();
   res.locals.response = {
-    trust_relationships: trustModel.get(),
+    trust_relationships: await trustModel.get(),
   }
   next();
 };

--- a/server/controllers/userController.js
+++ b/server/controllers/userController.js
@@ -11,117 +11,117 @@ const assert = require("assert");
  * or all trees in each managed sub-account wallets.
  * ________________________________________________________________________
 */
-userController.getTrees = async (req, res, next) => {
-  log.debug("getTree");
-  const errors = validationResult(req);
-  if (!errors.isEmpty()) {
-    next({
-      log: 'Error: Invalid wallet or limit format',
-      status: 422,
-      message: { err: errors.array() },
-    });
-  }
-  let { wallet } = req.query;
-  const entityId = res.locals.entity_id;
-  let walletEntityId = entityId;
+// userController.getTrees = async (req, res, next) => {
+//   log.debug("getTree");
+//   const errors = validationResult(req);
+//   if (!errors.isEmpty()) {
+//     next({
+//       log: 'Error: Invalid wallet or limit format',
+//       status: 422,
+//       message: { err: errors.array() },
+//     });
+//   }
+//   let { wallet } = req.query;
+//   const entityId = res.locals.entity_id;
+//   let walletEntityId = entityId;
 
-  if (wallet != null) {
-    console.log(wallet);
+//   if (wallet != null) {
+//     console.log(wallet);
 
-    // verify this user has access to this wallet
-    const query1 = {
-      text: `SELECT *
-      FROM entity 
-      WHERE wallet = $1`,
-      values: [wallet],
-    };
+//     // verify this user has access to this wallet
+//     const query1 = {
+//       text: `SELECT *
+//       FROM entity 
+//       WHERE wallet = $1`,
+//       values: [wallet],
+//     };
 
-    const rval1 = await pool.query(query1);
+//     const rval1 = await pool.query(query1);
 
-    if (rval1.rows.length === 0) {
-      next({
-        log: 'Error: Invalid wallet',
-        status: 404,
-        message: { err: 'Error: invalid wallet' },
-      });
-    }
-    walletEntityId = rval1.rows[0].id;
-  } else {
-    const query2 = {
-      text: `SELECT *
-      FROM entity 
-      WHERE id = $1`,
-      values: [walletEntityId],
-    };
-    const rval2 = await pool.query(query2);
-    wallet = rval2.rows[0].wallet;
-  }
+//     if (rval1.rows.length === 0) {
+//       next({
+//         log: 'Error: Invalid wallet',
+//         status: 404,
+//         message: { err: 'Error: invalid wallet' },
+//       });
+//     }
+//     walletEntityId = rval1.rows[0].id;
+//   } else {
+//     const query2 = {
+//       text: `SELECT *
+//       FROM entity 
+//       WHERE id = $1`,
+//       values: [walletEntityId],
+//     };
+//     const rval2 = await pool.query(query2);
+//     wallet = rval2.rows[0].wallet;
+//   }
 
-  const limitClause = req.query.limit ? `LIMIT ${req.query.limit}` : ' ';
-  const query3 = {
-    text: `SELECT token.*, image_url, lat, lon, 
-    tree_region.name AS region_name, 
-    trees.time_created AS tree_captured_at
-    FROM token
-    JOIN trees
-    ON trees.id = token.tree_id
-    LEFT JOIN (
-      SELECT DISTINCT name, tree_id
-      FROM tree_region
-      JOIN region
-      ON region.id = tree_region.region_id
-      WHERE zoom_level = 4
-    ) tree_region
-    ON tree_region.tree_id = trees.id 
-    WHERE entity_id = $1
-    ORDER BY tree_captured_at DESC
-    ${limitClause}`,
-    values: [walletEntityId],
-  };
-  log.debug("pg:", query3.text, query3.values);
-  const rval3 = await pool.query(query3);
+//   const limitClause = req.query.limit ? `LIMIT ${req.query.limit}` : ' ';
+//   const query3 = {
+//     text: `SELECT token.*, image_url, lat, lon, 
+//     tree_region.name AS region_name, 
+//     trees.time_created AS tree_captured_at
+//     FROM token
+//     JOIN trees
+//     ON trees.id = token.tree_id
+//     LEFT JOIN (
+//       SELECT DISTINCT name, tree_id
+//       FROM tree_region
+//       JOIN region
+//       ON region.id = tree_region.region_id
+//       WHERE zoom_level = 4
+//     ) tree_region
+//     ON tree_region.tree_id = trees.id 
+//     WHERE entity_id = $1
+//     ORDER BY tree_captured_at DESC
+//     ${limitClause}`,
+//     values: [walletEntityId],
+//   };
+//   log.debug("pg:", query3.text, query3.values);
+//   const rval3 = await pool.query(query3);
 
-  const trees = [];
-  if (rval3.rows.length !== 0) {
-    /*eslint-disable*/
-    for (token of rval3.rows) {
-      treeItem = {
-        token: token.uuid,
-        map_url: config.map_url + "?treeid="+token.tree_id,
-        image_url: token.image_url,
-        tree_captured_at: token.tree_captured_at,
-        latitude: token.lat,
-        longitude: token.lon,
-        region: token.region_name
-      }
-      trees.push(treeItem);
-    }
-  } 
-  const response = {
-    trees: trees,
-    wallet: wallet,
-    wallet_url: config.wallet_url + "?wallet="+wallet
-  };
-  res.locals.trees = response;
-  next();
-};
+//   const trees = [];
+//   if (rval3.rows.length !== 0) {
+//     /*eslint-disable*/
+//     for (token of rval3.rows) {
+//       treeItem = {
+//         token: token.uuid,
+//         map_url: config.map_url + "?treeid="+token.tree_id,
+//         image_url: token.image_url,
+//         tree_captured_at: token.tree_captured_at,
+//         latitude: token.lat,
+//         longitude: token.lon,
+//         region: token.region_name
+//       }
+//       trees.push(treeItem);
+//     }
+//   } 
+//   const response = {
+//     trees: trees,
+//     wallet: wallet,
+//     wallet_url: config.wallet_url + "?wallet="+wallet
+//   };
+//   res.locals.trees = response;
+//   next();
+// };
 
-const renderAccountData = (entity) => {
-  log.debug(entity);
-  let accountData = {
-    type: entity.type, 
-    wallet: entity.wallet,
-    email: entity.email,
-    phone: entity.phone
-  };
-  if (entity.type == 'p') {
-    accountData.first_name = entity.first_name;
-    accountData.last_name = entity.last_name;
-  } else if (entity.type == 'o') {
-    accountData.name = entity.name;
-  }
-  return accountData;
-};
+// const renderAccountData = (entity) => {
+//   log.debug(entity);
+//   let accountData = {
+//     type: entity.type, 
+//     wallet: entity.wallet,
+//     email: entity.email,
+//     phone: entity.phone
+//   };
+//   if (entity.type == 'p') {
+//     accountData.first_name = entity.first_name;
+//     accountData.last_name = entity.last_name;
+//   } else if (entity.type == 'o') {
+//     accountData.name = entity.name;
+//   }
+//   return accountData;
+// };
 
 /* ________________________________________________________________________
  * Get details of logged in account and sub-accounts.
@@ -768,12 +768,12 @@ userController.token = async (req, res, next) => {
     tree_region.name AS region_name,
     trees.time_created AS tree_captured_at
     FROM token
-    JOIN trees
+    JOIN public.trees AS trees
     ON trees.id = token.tree_id
     LEFT JOIN (
       SELECT DISTINCT  name, tree_id
-      FROM tree_region
-      JOIN region
+      FROM public.tree_region AS tree_region
+      JOIN public.region AS region
       ON region.id = tree_region.region_id
       WHERE zoom_level = 4
     ) tree_region

--- a/server/controllers/userController.js
+++ b/server/controllers/userController.js
@@ -756,7 +756,7 @@ userController.token = async (req, res, next) => {
   const {uuid} = req.params;
 
   if (!uuid) {
-    next({
+    return next({
       log: 'ERROR: No token supplied',
       status: 401,
       message: { err: 'ERROR: No token supplied' },
@@ -779,13 +779,13 @@ userController.token = async (req, res, next) => {
     ) tree_region
     ON tree_region.tree_id = trees.id 
     WHERE token.uuid = $1`,
-    values: [uuid]
-  }
+    values: [uuid],
+  };
   log.debug(query);
   const rval = await pool.query(query);
 
   const trees = [];
-  for(token of rval.rows){
+  for(token of rval.rows) {
     treeItem = {
       token: token.uuid,
       map_url: config.map_url + "?treeid="+token.tree_id,
@@ -797,12 +797,11 @@ userController.token = async (req, res, next) => {
     }
     trees.push(treeItem);
   }
-
   const response = {
     tokens: trees,
   };
   res.locals.response = response;
   next();
-}
+};
 
 module.exports = userController;

--- a/server/database/database.js
+++ b/server/database/database.js
@@ -7,6 +7,7 @@ const pool = new Pool({
 });
 
 pool.on('connect', (client) => {
+  client.query('SET search_path TO wallets, public;');
   //console.log("connected", client);
 });
 

--- a/server/database/knex.js
+++ b/server/database/knex.js
@@ -5,7 +5,7 @@ const knex = require('knex')({
   client: 'pg',
 //  debug: true,
   connection,
+  searchPath: ['wallets', 'public'],
 });
 
 module.exports = knex;
-

--- a/server/models/EntityModel.js
+++ b/server/models/EntityModel.js
@@ -10,7 +10,7 @@ class EntityModel {
   async getEntityByWalletName(wallet){
     expect(wallet, () => new HttpError(`invalid wallet name:${wallet}`))
       .match(/^\S+$/);
-    const list = await knex.select().table("wallets.wallet").where("name", wallet);
+    const list = await knex.select().table('wallets.wallet').where('name', wallet);
     expect(list, () => new HttpError(`can not find entity by wallet name:${wallet}`)).defined().lengthOf(1);
     return list[0];
   }

--- a/server/models/EntityModel.js
+++ b/server/models/EntityModel.js
@@ -10,7 +10,7 @@ class EntityModel {
   async getEntityByWalletName(wallet){
     expect(wallet, () => new HttpError(`invalid wallet name:${wallet}`))
       .match(/^\S+$/);
-    const list = await knex.select().table("entity").where("wallet", wallet);
+    const list = await knex.select().table("wallets.wallet").where("name", wallet);
     expect(list, () => new HttpError(`can not find entity by wallet name:${wallet}`)).defined().lengthOf(1);
     return list[0];
   }

--- a/server/models/EntityModel.spec.js
+++ b/server/models/EntityModel.spec.js
@@ -23,7 +23,7 @@ describe("EntityModel", () => {
 
   it("getEntityByWalletName", async () => {
     tracker.on("query", (query) => {
-      expect(query.sql).match(/select.*entity.*/);
+      expect(query.sql).match(/select.*wallet.*/);
       query.response([{
         id:1,
       }]);
@@ -37,7 +37,7 @@ describe("EntityModel", () => {
     tracker.install();
     tracker.on("query", (query) => {
       console.log("xxx");
-      expect(query.sql).match(/select.*entity.*/);
+      expect(query.sql).match(/select.*wallet.*/);
       query.response([]);
     });
     await jestExpect(async () => {

--- a/server/models/TrustModel.js
+++ b/server/models/TrustModel.js
@@ -17,12 +17,12 @@ class TrustModel{
     expect(walletName, () => new HttpError("Invalid wallet name", 400))
       .match(/\S+/);
     
-    //get entity id
+    //get wallet id
     const entityModel = new EntityModel();
-    const entity = await entityModel.getEntityByWalletName((walletName));
+    const wallet = await entityModel.getEntityByWalletName((walletName));
     await knex("entity_trust").insert({
       request_type: requestType,
-      target_entity_id: entity.id,
+      target_entity_id: wallet.id,
     });
   }
 }

--- a/server/models/TrustModel.js
+++ b/server/models/TrustModel.js
@@ -7,12 +7,12 @@ class TrustModel{
   async get(){
     //const trust_relationship_instance = new trust_relationship(1);
     const list = await knex.select()
-      .table("trust_relationship");
+      .table("wallets.entity_trust");
     return list;
   }
 
   async request(requestType, walletName){
-    expect(requestType, () => new HttpError(`The trust request type muse be one of ${Object.keys(TrustModel.ENTITY_TRUST_REQUEST_TYPE).join(',')}`, 400))
+    expect(requestType, () => new HttpError(`The trust request type must be one of ${Object.keys(TrustModel.ENTITY_TRUST_REQUEST_TYPE).join(',')}`, 400))
       .oneOf(Object.keys(TrustModel.ENTITY_TRUST_REQUEST_TYPE));
     expect(walletName, () => new HttpError("Invalid wallet name", 400))
       .match(/\S+/);
@@ -20,7 +20,7 @@ class TrustModel{
     //get wallet id
     const entityModel = new EntityModel();
     const wallet = await entityModel.getEntityByWalletName((walletName));
-    await knex("entity_trust").insert({
+    await knex("wallets.entity_trust").insert({
       request_type: requestType,
       target_entity_id: wallet.id,
     });
@@ -35,9 +35,9 @@ TrustModel.ENTITY_TRUST_TYPE = {
 
 TrustModel.ENTITY_TRUST_STATE_TYPE = {
   requested: 'requested',
-  cancelled_by_originator: 'cancelled_by_orginator',
-  canceled_by_actor: 'canceled_by_actor',
-  trusted: 'truested',
+  cancelled_by_originator: 'cancelled_by_originator',
+  canceled_by_actor: 'cancelled_by_actor',
+  trusted: 'trusted',
 }
 
 TrustModel.ENTITY_TRUST_REQUEST_TYPE = {

--- a/server/models/TrustModel.spec.js
+++ b/server/models/TrustModel.spec.js
@@ -22,7 +22,7 @@ describe("TrustModel", () => {
 
   it("get trust_relationships", async () => {
     tracker.on("query", (query) => {
-      expect(query.sql).match(/select.*trust_relationship.*/);
+      expect(query.sql).match(/select.*entity_trust.*/);
       query.response([{
         a:1,
       }]);
@@ -53,7 +53,7 @@ describe("TrustModel", () => {
       tracker.on("query", function sendResult(query, step){
         [
           function firstQuery(){
-            expect(query.sql).match(/select.*entity.*/);
+            expect(query.sql).match(/select.*wallet.*/);
             query.response([{
               id: 1,
             }]);

--- a/server/routes/router.js
+++ b/server/routes/router.js
@@ -19,15 +19,15 @@ router.post('/auth',
 
 // Routes that require logged in status
 
-router.get('/tree',
-  [
-    check('limit', 'Invalid limit number').optional().isNumeric({ min: 1, max: 1000 }),
-    check('wallet', 'Invalid wallet name').optional().isAlphanumeric(),
-  ],
-  authController.verifyJWT,
-  authController.checkAccess('list_trees'),
-  userController.getTrees,
-  (req, res) => res.status(200).json(res.locals.trees));
+// router.get('/tree',
+//   [
+//     check('limit', 'Invalid limit number').optional().isNumeric({ min: 1, max: 1000 }),
+//     check('wallet', 'Invalid wallet name').optional().isAlphanumeric(),
+//   ],
+//   authController.verifyJWT,
+//   authController.checkAccess('list_trees'),
+//   userController.getTrees,
+//   (req, res) => res.status(200).json(res.locals.trees));
 
 router.get('/token/:uuid',
   [
@@ -44,81 +44,81 @@ router.get('/token/:uuid',
   userController.token,
   (req, res) => res.status(200).json(res.locals.response));
 
-router.get('/account',
-  authController.verifyJWT,
-  authController.checkAccess('accounts'),
-  userController.getAccounts,
-  (req, res) => res.status(200).json(res.locals.accounts));
+// router.get('/account',
+//   authController.verifyJWT,
+//   authController.checkAccess('accounts'),
+//   userController.getAccounts,
+//   (req, res) => res.status(200).json(res.locals.accounts));
 
-router.post('/account',
-  [
-    check('wallet', 'Invalid wallet name').isAlphanumeric()
-  ],
-  authController.verifyJWT,
-  authController.checkAccess('manage_accounts'),
-  userController.addAccount,
-  (_, res) => {
-    assert(res.locals);
-    assert(res.locals.response);
-    res.status(200).json(res.locals.response);
-  });
+// router.post('/account',
+//   [
+//     check('wallet', 'Invalid wallet name').isAlphanumeric()
+//   ],
+//   authController.verifyJWT,
+//   authController.checkAccess('manage_accounts'),
+//   userController.addAccount,
+//   (_, res) => {
+//     assert(res.locals);
+//     assert(res.locals.response);
+//     res.status(200).json(res.locals.response);
+//   });
 
-router.post('/transfer',
-  [
-    check('tokens[*].*').isUUID(),
-    check('sender_wallet', 'Invalid Sender wallet name').isAlphanumeric(),
-    check('receiver_wallet', 'Invalid Reciever wallet name').isAlphanumeric()
-  ],
-  authController.verifyJWT,
-  authController.checkAccess('manage_accounts'),
-  userController.transfer,
-  (_, res) => {
-    assert(res.locals);
-    assert(res.locals.response);
-    res.status(200).json(res.locals.response);
-  });
+// router.post('/transfer',
+//   [
+//     check('tokens[*].*').isUUID(),
+//     check('sender_wallet', 'Invalid Sender wallet name').isAlphanumeric(),
+//     check('receiver_wallet', 'Invalid Reciever wallet name').isAlphanumeric()
+//   ],
+//   authController.verifyJWT,
+//   authController.checkAccess('manage_accounts'),
+//   userController.transfer,
+//   (_, res) => {
+//     assert(res.locals);
+//     assert(res.locals.response);
+//     res.status(200).json(res.locals.response);
+//   });
 
-router.post('/send',
-[
-  check('tokens[*].*').isUUID(),
-  check('receiver_wallet', 'Invalid Receiver wallet name').isAlphanumeric(),
-],
-  authController.verifyJWT,
-  authController.checkAccess('manage_accounts'),
-  userController.send,
-  (_, res) => {
-    assert(res.locals);
-    assert(res.locals.response);
-    res.status(200).json(res.locals.response);
-  });
+// router.post('/send',
+// [
+//   check('tokens[*].*').isUUID(),
+//   check('receiver_wallet', 'Invalid Receiver wallet name').isAlphanumeric(),
+// ],
+//   authController.verifyJWT,
+//   authController.checkAccess('manage_accounts'),
+//   userController.send,
+//   (_, res) => {
+//     assert(res.locals);
+//     assert(res.locals.response);
+//     res.status(200).json(res.locals.response);
+//   });
 
-router.post('/transfer/bundle',
-  [
-    check('bundle_size').isNumeric(),
-    check('sender_wallet', 'Invalid Sender wallet name').isAlphanumeric(),
-    check('receiver_wallet', 'Invalid Reciever wallet name').isAlphanumeric()
-  ],
-  authController.verifyJWT,
-  authController.checkAccess('manage_accounts'),
-  userController.transferBundle,
-  (_, res) => {
-    assert(res.locals);
-    assert(res.locals.response);
-    res.status(200).json(res.locals.response);
-  });
+// router.post('/transfer/bundle',
+//   [
+//     check('bundle_size').isNumeric(),
+//     check('sender_wallet', 'Invalid Sender wallet name').isAlphanumeric(),
+//     check('receiver_wallet', 'Invalid Reciever wallet name').isAlphanumeric()
+//   ],
+//   authController.verifyJWT,
+//   authController.checkAccess('manage_accounts'),
+//   userController.transferBundle,
+//   (_, res) => {
+//     assert(res.locals);
+//     assert(res.locals.response);
+//     res.status(200).json(res.locals.response);
+//   });
 
-router.get('/history',
-  [
-    check('token').isUUID()
-  ],
-  authController.verifyJWT,
-  authController.checkAccess('manage_accounts'),
-  userController.history,
-  (_, res) => {
-    assert(res.locals);
-    assert(res.locals.response);
-    res.status(200).json(res.locals.response);
-  });
+// router.get('/history',
+//   [
+//     check('token').isUUID()
+//   ],
+//   authController.verifyJWT,
+//   authController.checkAccess('manage_accounts'),
+//   userController.history,
+//   (_, res) => {
+//     assert(res.locals);
+//     assert(res.locals.response);
+//     res.status(200).json(res.locals.response);
+//   });
 
 router.get('/trust_relationships',
 //  [

--- a/server/routes/router.js
+++ b/server/routes/router.js
@@ -19,16 +19,6 @@ router.post('/auth',
 
 // Routes that require logged in status
 
-// router.get('/tree',
-//   [
-//     check('limit', 'Invalid limit number').optional().isNumeric({ min: 1, max: 1000 }),
-//     check('wallet', 'Invalid wallet name').optional().isAlphanumeric(),
-//   ],
-//   authController.verifyJWT,
-//   authController.checkAccess('list_trees'),
-//   userController.getTrees,
-//   (req, res) => res.status(200).json(res.locals.trees));
-
 router.get('/token/:uuid',
   // [
   //   TODO ? check('limit', 'Invalid limit number').optional().isNumeric({ min: 1, max: 1000 }),
@@ -72,6 +62,16 @@ router.post('/trust_relationships',
 );
 
 /* __________________________OLD TESTS FOR PREVIOUS API VERSION___________________________
+
+// router.get('/tree',
+//   [
+//     check('limit', 'Invalid limit number').optional().isNumeric({ min: 1, max: 1000 }),
+//     check('wallet', 'Invalid wallet name').optional().isAlphanumeric(),
+//   ],
+//   authController.verifyJWT,
+//   authController.checkAccess('list_trees'),
+//   userController.getTrees,
+//   (req, res) => res.status(200).json(res.locals.trees));
 
 router.get('/account',
   authController.verifyJWT,

--- a/server/routes/router.js
+++ b/server/routes/router.js
@@ -30,95 +30,19 @@ router.post('/auth',
 //   (req, res) => res.status(200).json(res.locals.trees));
 
 router.get('/token/:uuid',
-  [
-    //TODO ? check('limit', 'Invalid limit number').optional().isNumeric({ min: 1, max: 1000 }),
-    //TODO ? check('wallet', 'Invalid wallet name').optional().isAlphanumeric(),
-  ],
+  // [
+  //   TODO ? check('limit', 'Invalid limit number').optional().isNumeric({ min: 1, max: 1000 }),
+  //   TODO ? check('wallet', 'Invalid wallet name').optional().isAlphanumeric(),
+  // ],
   authController.verifyJWT,
 //TODO ? didn't defined access role for GET /token
 //  (req, res, next) => {
 //    res.locals.role = 'list_trees';
 //    next();
 //  },
-//  authController.checkAccess,
+  // authController.checkAccess('list_trees'),
   userController.token,
   (req, res) => res.status(200).json(res.locals.response));
-
-// router.get('/account',
-//   authController.verifyJWT,
-//   authController.checkAccess('accounts'),
-//   userController.getAccounts,
-//   (req, res) => res.status(200).json(res.locals.accounts));
-
-// router.post('/account',
-//   [
-//     check('wallet', 'Invalid wallet name').isAlphanumeric()
-//   ],
-//   authController.verifyJWT,
-//   authController.checkAccess('manage_accounts'),
-//   userController.addAccount,
-//   (_, res) => {
-//     assert(res.locals);
-//     assert(res.locals.response);
-//     res.status(200).json(res.locals.response);
-//   });
-
-// router.post('/transfer',
-//   [
-//     check('tokens[*].*').isUUID(),
-//     check('sender_wallet', 'Invalid Sender wallet name').isAlphanumeric(),
-//     check('receiver_wallet', 'Invalid Reciever wallet name').isAlphanumeric()
-//   ],
-//   authController.verifyJWT,
-//   authController.checkAccess('manage_accounts'),
-//   userController.transfer,
-//   (_, res) => {
-//     assert(res.locals);
-//     assert(res.locals.response);
-//     res.status(200).json(res.locals.response);
-//   });
-
-// router.post('/send',
-// [
-//   check('tokens[*].*').isUUID(),
-//   check('receiver_wallet', 'Invalid Receiver wallet name').isAlphanumeric(),
-// ],
-//   authController.verifyJWT,
-//   authController.checkAccess('manage_accounts'),
-//   userController.send,
-//   (_, res) => {
-//     assert(res.locals);
-//     assert(res.locals.response);
-//     res.status(200).json(res.locals.response);
-//   });
-
-// router.post('/transfer/bundle',
-//   [
-//     check('bundle_size').isNumeric(),
-//     check('sender_wallet', 'Invalid Sender wallet name').isAlphanumeric(),
-//     check('receiver_wallet', 'Invalid Reciever wallet name').isAlphanumeric()
-//   ],
-//   authController.verifyJWT,
-//   authController.checkAccess('manage_accounts'),
-//   userController.transferBundle,
-//   (_, res) => {
-//     assert(res.locals);
-//     assert(res.locals.response);
-//     res.status(200).json(res.locals.response);
-//   });
-
-// router.get('/history',
-//   [
-//     check('token').isUUID()
-//   ],
-//   authController.verifyJWT,
-//   authController.checkAccess('manage_accounts'),
-//   userController.history,
-//   (_, res) => {
-//     assert(res.locals);
-//     assert(res.locals.response);
-//     res.status(200).json(res.locals.response);
-//   });
 
 router.get('/trust_relationships',
 //  [
@@ -146,6 +70,87 @@ router.post('/trust_relationships',
     res.status(200).json({todo:'todo'});
   },
 );
+
+/* __________________________OLD TESTS FOR PREVIOUS API VERSION___________________________
+
+router.get('/account',
+  authController.verifyJWT,
+  authController.checkAccess('accounts'),
+  userController.getAccounts,
+  (req, res) => res.status(200).json(res.locals.accounts));
+
+router.post('/account',
+  [
+    check('wallet', 'Invalid wallet name').isAlphanumeric()
+  ],
+  authController.verifyJWT,
+  authController.checkAccess('manage_accounts'),
+  userController.addAccount,
+  (_, res) => {
+    assert(res.locals);
+    assert(res.locals.response);
+    res.status(200).json(res.locals.response);
+  });
+
+router.post('/transfer',
+  [
+    check('tokens[*].*').isUUID(),
+    check('sender_wallet', 'Invalid Sender wallet name').isAlphanumeric(),
+    check('receiver_wallet', 'Invalid Reciever wallet name').isAlphanumeric()
+  ],
+  authController.verifyJWT,
+  authController.checkAccess('manage_accounts'),
+  userController.transfer,
+  (_, res) => {
+    assert(res.locals);
+    assert(res.locals.response);
+    res.status(200).json(res.locals.response);
+  });
+
+router.post('/send',
+[
+  check('tokens[*].*').isUUID(),
+  check('receiver_wallet', 'Invalid Receiver wallet name').isAlphanumeric(),
+],
+  authController.verifyJWT,
+  authController.checkAccess('manage_accounts'),
+  userController.send,
+  (_, res) => {
+    assert(res.locals);
+    assert(res.locals.response);
+    res.status(200).json(res.locals.response);
+  });
+
+router.post('/transfer/bundle',
+  [
+    check('bundle_size').isNumeric(),
+    check('sender_wallet', 'Invalid Sender wallet name').isAlphanumeric(),
+    check('receiver_wallet', 'Invalid Reciever wallet name').isAlphanumeric()
+  ],
+  authController.verifyJWT,
+  authController.checkAccess('manage_accounts'),
+  userController.transferBundle,
+  (_, res) => {
+    assert(res.locals);
+    assert(res.locals.response);
+    res.status(200).json(res.locals.response);
+  });
+
+router.get('/history',
+  [
+    check('token').isUUID()
+  ],
+  authController.verifyJWT,
+  authController.checkAccess('manage_accounts'),
+  userController.history,
+  (_, res) => {
+    assert(res.locals);
+    assert(res.locals.response);
+    res.status(200).json(res.locals.response);
+  });
+*/
+
+
 
 
 module.exports = router;

--- a/server/routes/router.js
+++ b/server/routes/router.js
@@ -30,7 +30,7 @@ router.get('/token/:uuid',
 //    res.locals.role = 'list_trees';
 //    next();
 //  },
-  // authController.checkAccess('list_trees'),
+  authController.checkAccess('list_trees'),
   userController.token,
   (req, res) => res.status(200).json(res.locals.response));
 


### PR DESCRIPTION
I cleaned up our codebase and tests to only focus on routes that overlap with the older API version, and rewrote some of the existing code so that we're leveraging a wallet table in our contained wallets schema (reflected in our migrations folder) instead of an entity table in the public schema. Now, when a connection is made to the db pool, it will automatically set the db search path to "wallets". We should try to do something similar for knex too, but for now I'm calling it by wallets.[tablename].
Both unit and integration tests pass (reduced to 6 each now). I think this will be a good starting point for us to write out the new specs and reference any previous commented out code (especially for the get/accounts -> get/wallets routes which are pretty similar). 


