### PR TITLE
Adds get wallet by id or name in /auth and /transfer

### DIFF
--- a/__tests__/supertest.js
+++ b/__tests__/supertest.js
@@ -101,7 +101,7 @@ describe('Wallet integration tests', () => {
         .send({
           tokens: [seed.token.uuid],
           sender_wallet: seed.wallet.name,
-          receiver_wallet: seed.walletB.id,
+          receiver_wallet: seed.walletB.name,
         });
       expect(res).property("statusCode").to.eq(202);
       expect(res).property("body").property("id").a("number");

--- a/__tests__/supertest.js
+++ b/__tests__/supertest.js
@@ -157,7 +157,7 @@ describe('Wallet integration tests', () => {
             expect(res).to.have.property('statusCode', 200);
           })
 
-          it(`Wallet:${seed.wallet.name} should be able to find the transfer, it should be completed`, async () => {
+          it(`Wallet:${seed.wallet.name} should be able to find the transfer, it should be completed 1`, async () => {
             const res = await request(server)
               .get(`/transfers`)
               .set('treetracker-api-key', apiKey)
@@ -466,7 +466,7 @@ describe('Wallet integration tests', () => {
             expect(res).to.have.property('statusCode', 200);
           })
 
-          it(`Wallet:${seed.wallet.name} should be able to find the transfer, it should be completed`, async () => {
+          it(`Wallet:${seed.wallet.name} should be able to find the transfer, it should be completed 2`, async () => {
             const res = await request(server)
               .get(`/transfers`)
               .set('treetracker-api-key', apiKey)

--- a/__tests__/supertest.js
+++ b/__tests__/supertest.js
@@ -101,7 +101,7 @@ describe('Wallet integration tests', () => {
         .send({
           tokens: [seed.token.uuid],
           sender_wallet: seed.wallet.name,
-          receiver_wallet: seed.walletB.name,
+          receiver_wallet: seed.walletB.id,
         });
       expect(res).property("statusCode").to.eq(202);
       expect(res).property("body").property("id").a("number");

--- a/__tests__/supertest.js
+++ b/__tests__/supertest.js
@@ -65,6 +65,20 @@ describe('Wallet integration tests', () => {
       });
   });
 
+  it(`[POST /auth] login with using wallet id: ${seed.wallet.id}`, (done) => {
+    request(server)
+      .post('/auth')
+      .set('treetracker-api-key', apiKey)
+      .send({wallet: seed.wallet.id, password: seed.wallet.password})
+      .expect('Content-Type', /application\/json/)
+      .expect(200)
+      .end((err, res) => {
+        if (err) done(err);
+        expect(res.body).to.have.property('token');
+        done();
+      });
+  });
+
   // Tests that require logged-in authorization
 
   it(`[GET /tokens/${seed.token.uuid}] Should be able to get a token `, async () => {

--- a/docs/api/spec/treetracker-token-api.yaml
+++ b/docs/api/spec/treetracker-token-api.yaml
@@ -26,8 +26,8 @@ paths:
                   password: walnut
               ByName:
                 value:
-              wallet: zaven
-              password: walnut
+                  wallet: zaven
+                  password: walnut
         required: true
       responses:
         '200':
@@ -158,7 +158,7 @@ paths:
       tags: 
       - Transfers
       summary: 'Move, request, and send tokens between wallets'
-      description: 'Move, request, and send tokens between wallets as allowed by trust relationships.  Transfer can be created/requested either using an explicit list of token ids or by specifying a bundle of tokens using tags and a count of tokens to attempt to transfer.  The originator of the request (currently logged in wallet) is used by the server code to compute who the originating wallet is for this request, whether the request is a credit, debut, or managed transfer, and if appropriate trust relationships exist to automatically execute or if it must be stored as a request until approval'
+      description: 'Move, request, and send tokens between wallets (by name or id) as allowed by trust relationships.  Transfer can be created/requested either using an explicit list of token ids or by specifying a bundle of tokens using tags and a count of tokens to attempt to transfer.  The originator of the request (currently logged in wallet) is used by the server code to compute who the originating wallet is for this request, whether the request is a credit, debut, or managed transfer, and if appropriate trust relationships exist to automatically execute or if it must be stored as a request until approval'
       parameters:
         - $ref: '#/components/parameters/treetrackerApiKeyParam'
         - $ref: '#/components/parameters/contentTypeJsonHeader'
@@ -175,7 +175,7 @@ paths:
                     - e1b278e8-f025-44b7-9dd8-36ffb2d58f7e
                     - e533653e-2dbf-48cd-940a-a87e5a393158
                   sender_wallet: zaven4
-                  receiver_wallet: zaven
+                  receiver_wallet: 2
               Bundle:
                 value:
                   bundle:
@@ -202,7 +202,7 @@ paths:
       tags:
       - Transfers
       summary: 'Get requested, pending, completed, cancelled, and failed transfers'
-      description: 'Get requested, pending, completed, cancelled and failed transfers for wallets the authenticated wallet is either the source, destination, or originating wallet entity.'
+      description: 'Get requested, pending, completed, cancelled and failed transfers for wallets (by name or id). The authenticated wallet is either the source, destination, or originating wallet entity.'
       parameters:
         - $ref: '#/components/parameters/treetrackerApiKeyParam'
         - $ref: '#/components/parameters/contentTypeJsonHeader'
@@ -215,9 +215,11 @@ paths:
         - in: query
           name: wallet
           schema:
-            type: string
+            oneOf:
+              - type: string
+              - type: number
           required: false
-          description: filter transfers matches the source, destination, or originating wallet of a transfer
+          description: filter transfers matches the source, destination, or originating wallet (by name or id) of a transfer
       responses:
         '200':
           description: 'Return array of matching transfers'
@@ -402,10 +404,12 @@ paths:
             format: timestamp
             example: 2019-10-12T07:20:50.52Z
         - name: wallet
-          description: "Wallet can be specified if the authenticated wallet manages other wallets.  The default is to return events matching the authenticated wallet"
+          description: "Wallet (by name or id) can be specified if the authenticated wallet manages other wallets.  The default is to return events matching the authenticated wallet"
           in: query
           schema:
-            type: string
+            oneOf:
+              - type: string
+              - type: number
             example: zaven2
       responses:
         '200':
@@ -593,7 +597,7 @@ components:
       required: true
       style: simple
       schema:
-        type: string
+          type: string
     contentTypeJsonHeader:
       name: Content-Type
       in: header
@@ -725,9 +729,13 @@ components:
                 type: string
                 description: "optional list of tags that trees must match ALL of"
         sender_wallet:
-          type: string
+          oneOf:
+          - type: string
+          - type: number
         receiver_wallet:
-          type: string
+          oneOf:
+          - type: string
+          - type: number
       example:
         tokens:
           - e1b278e8-f025-44b7-9dd8-36ffb2d58f7e
@@ -745,9 +753,13 @@ components:
         parameters:
           $ref: "#/components/schemas/requestBundleRequestParameters"
         sender_wallet:
-          type: string
+          oneOf:
+          - type: string
+          - type: number
         receiver_wallet:
-          type: string
+          oneOf:
+          - type: string
+          - type: number
       example:
         bundle_size: 500
         sender_wallet: zaven
@@ -765,7 +777,9 @@ components:
             type: string
           description: ''
         receiver_wallet:
-          type: string
+          oneOf:
+          - type: string
+          - type: number
       example:
         tokens:
           - e1b278e8-f025-44b7-9dd8-36ffb2d58f7e

--- a/docs/api/spec/treetracker-token-api.yaml
+++ b/docs/api/spec/treetracker-token-api.yaml
@@ -9,7 +9,7 @@ paths:
       tags: 
       - Authentication
       summary: "Authenticate account"
-      description: "Authenticate the client using wallet name and password, and respond with a bearer token"
+      description: "Authenticate the client using wallet name or id and password, and respond with a bearer token"
       parameters:
         - $ref: '#/components/parameters/treetrackerApiKeyParam'
         - $ref: '#/components/parameters/contentTypeJsonHeader'
@@ -19,7 +19,13 @@ paths:
           application/json:
             schema:
               $ref: '#/components/schemas/authrequest'
-            example:
+            examples:
+              ById:
+                value:
+                  wallet: 1
+                  password: walnut
+              ByName:
+                value:
               wallet: zaven
               password: walnut
         required: true
@@ -58,10 +64,12 @@ paths:
             items: 
               type: string
         - name: wallet
-          description: "Wallet can be specified if the authenticated wallet manages other wallets.  The default is to return tokens matching the authenticated wallet"
+          description: "Wallet id or name can be specified if the authenticated wallet manages other wallets.  The default is to return tokens matching the authenticated wallet"
           in: query
           schema:
-            type: string
+            oneOf:
+              - type: string
+              - type: number
             example: zaven2
         - name: token
           description: ""
@@ -604,7 +612,9 @@ components:
       type: object
       properties:
         wallet:
-          type: string
+          oneOf:
+          - type: string
+          - type: number
         password:
           type: string
       example:

--- a/server/routes/authRouter.js
+++ b/server/routes/authRouter.js
@@ -27,13 +27,7 @@ authRouter.post(
     const { wallet, password } = req.body;
     const walletService = new WalletService();
     
-    let walletObject;
-    if (isNaN(wallet)) {
-      walletObject = await walletService.getByName(wallet);
-    }
-    else{
-      walletObject = await walletService.getById(wallet);
-    }
+    let walletObject = await walletService.getByIdOrName(wallet);
     walletObject = await walletObject.authorize(password);
 
     const jwtService = new JWTService();

--- a/server/routes/transferRouter.js
+++ b/server/routes/transferRouter.js
@@ -26,11 +26,11 @@ transferRouter.post(
           tokens: Joi.array().items(Joi.string()).required(),
           sender_wallet: Joi.alternatives().try(
             Joi.string().alphanum().min(4).max(32),
-            Joi.number().min(4).max(32)
+            Joi.number().min(1).max(32)
           ).required(),
           receiver_wallet: Joi.alternatives().try(
             Joi.string().alphanum().min(4).max(32),
-            Joi.number().min(4).max(32)
+            Joi.number().min(1).max(32)
           ).required(),
         }),
         otherwise: Joi.object({

--- a/server/routes/transferRouter.js
+++ b/server/routes/transferRouter.js
@@ -1,18 +1,17 @@
-const express = require('express');
+const express = require("express");
 const transferRouter = express.Router();
 const WalletService = require("../services/WalletService");
 const TransferService = require("../services/TransferService");
 const Wallet = require("../models/Wallet");
 const TrustRelationship = require("../models/TrustRelationship");
-const expect = require("expect-runtime");
 const helper = require("./utils");
 const Joi = require("joi");
 const TokenService = require("../services/TokenService");
 const HttpError = require("../utils/HttpError");
 const Transfer = require("../models/Transfer");
 
-
-transferRouter.post('/',
+transferRouter.post(
+  "/",
   helper.apiKeyHandler,
   helper.verifyJWTHandler,
   helper.handlerWrapper(async (req, res) => {
@@ -25,10 +24,14 @@ transferRouter.post('/',
       }).unknown(),{
         then: Joi.object({
           tokens: Joi.array().items(Joi.string()).required(),
-          sender_wallet: Joi.string()
-          .required(),
-          receiver_wallet: Joi.string()
-          .required(),
+          sender_wallet: Joi.alternatives().try(
+            Joi.string().alphanum().min(4).max(32),
+            Joi.number().min(4).max(32)
+          ).required(),
+          receiver_wallet: Joi.alternatives().try(
+            Joi.string().alphanum().min(4).max(32),
+            Joi.number().min(4).max(32)
+          ).required(),
         }),
         otherwise: Joi.object({
           bundle: Joi.object({
@@ -43,8 +46,21 @@ transferRouter.post('/',
     );
     const walletService = new WalletService();
     const walletLogin = await walletService.getById(res.locals.wallet_id);
-    const walletSender = await walletService.getByName(req.body.sender_wallet);
-    const walletReceiver = await walletService.getByName(req.body.receiver_wallet);
+
+    let walletSender;
+    if (isNaN(req.body.sender_wallet)) {
+      walletSender = await walletService.getByName(req.body.sender_wallet);
+    } else {
+      walletSender = await walletService.getById(req.body.sender_wallet);
+    }
+
+    let walletReceiver;
+    if (isNaN(req.body.receiver_wallet)) {
+      walletReceiver = await walletService.getByName(req.body.receiver_wallet);
+    } else {
+      walletReceiver = await walletService.getById(req.body.receiver_wallet);
+    }
+
     let result;
     if(req.body.tokens){
       const tokens = [];
@@ -151,10 +167,32 @@ transferRouter.get("/",
   helper.apiKeyHandler,
   helper.verifyJWTHandler,
   helper.handlerWrapper(async (req, res) => {
+    Joi.assert(
+      req.query,
+      Joi.object({
+        state: Joi.string()
+          .valid(...Object.values(Transfer.STATE)),
+        wallet: Joi.alternatives().try(
+          Joi.string().alphanum().min(4).max(32),
+          Joi.number().min(4).max(32)
+        ),
+      })
+    );
     const {state, wallet} = req.query;
     const walletService = new WalletService();
     const walletLogin = await walletService.getById(res.locals.wallet_id);
-    const result = await walletLogin.getTransfers(state, wallet);
+
+    let walletObject;
+    if(wallet){
+      if (isNaN(wallet)) {
+        walletObject = await walletService.getByName(wallet);
+      } else {
+        walletObject = await walletService.getById(wallet);
+      }
+    }
+    
+    
+    const result = await walletLogin.getTransfers(state, walletObject);
     const transferService = new TransferService();
     const json = [];
     for(let t of result){
@@ -164,6 +202,5 @@ transferRouter.get("/",
     res.status(200).json({transfers: json});
   })
 );
-
 
 module.exports = transferRouter;

--- a/server/routes/transferRouter.js
+++ b/server/routes/transferRouter.js
@@ -47,19 +47,8 @@ transferRouter.post(
     const walletService = new WalletService();
     const walletLogin = await walletService.getById(res.locals.wallet_id);
 
-    let walletSender;
-    if (isNaN(req.body.sender_wallet)) {
-      walletSender = await walletService.getByName(req.body.sender_wallet);
-    } else {
-      walletSender = await walletService.getById(req.body.sender_wallet);
-    }
-
-    let walletReceiver;
-    if (isNaN(req.body.receiver_wallet)) {
-      walletReceiver = await walletService.getByName(req.body.receiver_wallet);
-    } else {
-      walletReceiver = await walletService.getById(req.body.receiver_wallet);
-    }
+    const walletSender = await walletService.getByIdOrName(req.body.sender_wallet);
+    const walletReceiver = await walletService.getByIdOrName(req.body.receiver_wallet);
 
     let result;
     if(req.body.tokens){
@@ -181,16 +170,10 @@ transferRouter.get("/",
     const {state, wallet} = req.query;
     const walletService = new WalletService();
     const walletLogin = await walletService.getById(res.locals.wallet_id);
-
     let walletObject;
     if(wallet){
-      if (isNaN(wallet)) {
-        walletObject = await walletService.getByName(wallet);
-      } else {
-        walletObject = await walletService.getById(wallet);
-      }
+      walletObject = await walletService.getByIdOrName(wallet);
     }
-    
     
     const result = await walletLogin.getTransfers(state, walletObject);
     const transferService = new TransferService();

--- a/server/routes/transferRouter.spec.js
+++ b/server/routes/transferRouter.spec.js
@@ -64,7 +64,7 @@ describe("authRouter", () => {
       .stub(WalletService.prototype, 'getById')
       .resolves(new Wallet(1));
     sinon
-      .stub(WalletService.prototype, 'getByName')
+      .stub(WalletService.prototype, 'getByIdOrName')
       .onFirstCall()
       .resolves(new Wallet(1))
       .onSecondCall()
@@ -97,11 +97,13 @@ describe("authRouter", () => {
     sinon
       .stub(WalletService.prototype, 'getById')
       .onFirstCall()
+      .resolves(new Wallet(1));
+    sinon
+      .stub(WalletService.prototype, 'getByIdOrName')
+      .onFirstCall()
       .resolves(new Wallet(1))
       .onSecondCall()
-      .resolves(new Wallet(2))
-      .onThirdCall()
-      .resolves(new Wallet(3))
+      .resolves(new Wallet(2));
 
     sinon.stub(TokenService.prototype, 'getByUUID').resolves(
       new Token({
@@ -128,7 +130,7 @@ describe("authRouter", () => {
   });
 
   it("all parameters fine, but no trust relationship, should return 202", async () => {
-    sinon.stub(WalletService.prototype, "getByName").resolves(new Wallet(1));
+    sinon.stub(WalletService.prototype, "getByIdOrName").resolves(new Wallet(1));
     sinon.stub(WalletService.prototype, "getById").resolves({
       transfer: () => {},
     });
@@ -153,7 +155,7 @@ describe("authRouter", () => {
   });
 
   it("bundle case, success, should return 201", async () => {
-    sinon.stub(WalletService.prototype, "getByName").resolves(new Wallet(1));
+    sinon.stub(WalletService.prototype, "getByIdOrName").resolves(new Wallet(1));
     sinon.stub(WalletService.prototype, "getById").resolves({
       transfer: () => {},
     });

--- a/server/routes/transferRouter.spec.js
+++ b/server/routes/transferRouter.spec.js
@@ -59,29 +59,72 @@ describe("authRouter", () => {
     expect(res.body.message).match(/sender.*required/);
   });
 
-  it("all parameters fine, should return 201", async () => {
-    sinon.stub(WalletService.prototype, "getByName").resolves(new Wallet(1));
-    sinon.stub(WalletService.prototype, "getById").resolves(new Wallet(2));
-    sinon.stub(TokenService.prototype,"getByUUID").resolves(new Token({
-      id: 1,
-      entity_id: 1,
-    }));
-    sinon.stub(Wallet.prototype, "transfer").resolves({
+  it('transfer using sender and receiver name, should return 201', async () => {
+    sinon
+      .stub(WalletService.prototype, 'getById')
+      .resolves(new Wallet(1));
+    sinon
+      .stub(WalletService.prototype, 'getByName')
+      .onFirstCall()
+      .resolves(new Wallet(1))
+      .onSecondCall()
+      .resolves(new Wallet(2));
+    sinon.stub(TokenService.prototype, 'getByUUID').resolves(
+      new Token({
+        id: 1,
+        entity_id: 1,
+      }),
+    );
+    sinon.stub(Wallet.prototype, 'transfer').resolves({
       id: 1,
       state: Transfer.STATE.completed,
     });
-    sinon.stub(TransferService.prototype, "convertToResponse").resolves({
-      id:1,
+    sinon.stub(TransferService.prototype, 'convertToResponse').resolves({
+      id: 1,
       state: Transfer.STATE.completed,
     });
     const res = await request(app)
-      .post("/")
+      .post('/')
       .send({
-        tokens: ["1"],
-        sender_wallet: "ssss",
-        receiver_wallet: "ssss",
+        tokens: ['1'],
+        sender_wallet: 'wallet1',
+        receiver_wallet: 'wallet2',
       });
-    expect(res).property("statusCode").eq(201);
+    expect(res).property('statusCode').eq(201);
+  });
+
+  it('Transfer using sender and receiver id, should return 201', async () => {
+    sinon
+      .stub(WalletService.prototype, 'getById')
+      .onFirstCall()
+      .resolves(new Wallet(1))
+      .onSecondCall()
+      .resolves(new Wallet(2))
+      .onThirdCall()
+      .resolves(new Wallet(3))
+
+    sinon.stub(TokenService.prototype, 'getByUUID').resolves(
+      new Token({
+        id: 1,
+        entity_id: 1,
+      }),
+    );
+    sinon.stub(Wallet.prototype, 'transfer').resolves({
+      id: 1,
+      state: Transfer.STATE.completed,
+    });
+    sinon.stub(TransferService.prototype, 'convertToResponse').resolves({
+      id: 1,
+      state: Transfer.STATE.completed,
+    });
+    const res = await request(app)
+      .post('/')
+      .send({
+        tokens: ['1'],
+        sender_wallet: 1,
+        receiver_wallet: 2,
+      });
+    expect(res).property('statusCode').eq(201);
   });
 
   it("all parameters fine, but no trust relationship, should return 202", async () => {

--- a/server/services/WalletService.js
+++ b/server/services/WalletService.js
@@ -29,7 +29,7 @@ class WalletService {
     } else if (typeof idOrName === 'string') {
       walletObject = await this.walletRepository.getByName(idOrName);
     } else {
-      throw new HttpError(404, `Could not find wallet by id or name: ${idOrName}`);
+      throw new HttpError(404, `Type must be number or string: ${idOrName}`);
     }
 
     expect(walletObject).match({ id: expect.any(Number) });

--- a/server/services/WalletService.js
+++ b/server/services/WalletService.js
@@ -1,22 +1,39 @@
-const WalletRepository = require("../repositories/WalletRepository");
-const Wallet = require("../models/Wallet");
-const expect = require("expect-runtime");
+const WalletRepository = require('../repositories/WalletRepository');
+const Wallet = require('../models/Wallet');
+const HttpError = require("../utils/HttpError");
+const expect = require('expect-runtime');
 
-class WalletService{
-  constructor(){
+class WalletService {
+  constructor() {
     this.walletRepository = new WalletRepository();
   }
 
-  async getById(id){
+  async getById(id) {
     const object = await this.walletRepository.getById(id);
+    expect(object).match({ id: expect.any(Number) });
     const wallet = new Wallet(object.id);
     return wallet;
   }
 
-  async getByName(name){
+  async getByName(name) {
     const object = await this.walletRepository.getByName(name);
-    expect(object).match({id:expect.any(Number)});
+    expect(object).match({ id: expect.any(Number) });
     const wallet = new Wallet(object.id);
+    return wallet;
+  }
+
+  async getByIdOrName(idOrName) {
+    let walletObject;
+    if (typeof idOrName === 'number') {
+      walletObject = await this.walletRepository.getById(idOrName);
+    } else if (typeof idOrName === 'string') {
+      walletObject = await this.walletRepository.getByName(idOrName);
+    } else {
+      throw new HttpError(404, `Could not find wallet by id or name: ${idOrName}`);
+    }
+
+    expect(walletObject).match({ id: expect.any(Number) });
+    const wallet = new Wallet(walletObject.id);
     return wallet;
   }
 }

--- a/server/services/WalletService.spec.js
+++ b/server/services/WalletService.spec.js
@@ -11,7 +11,12 @@ describe("WalletService", () => {
     walletService = new WalletService();
   })
 
-  it("getById", () => {
+  it("getById", async () => {
+    sinon.stub(WalletRepository.prototype, "getById").resolves({id:1});
+    expect(walletService).instanceOf(WalletService);
+    const wallet = await walletService.getById(1);
+    expect(wallet).instanceOf(Wallet);
+    WalletRepository.prototype.getById.restore();
   });
 
   it("getByName", async () => {
@@ -21,6 +26,5 @@ describe("WalletService", () => {
     expect(wallet).instanceOf(Wallet);
     WalletRepository.prototype.getByName.restore();
   });
-
 });
 


### PR DESCRIPTION
Adds support for handling both numbers or strings in the wallet parameter, allowing for the user to use them interchangeably https://github.com/Greenstand/treetracker-wallet-api/issues/35

getting a few repository test errors, and a few more pending, but I think they are unrelated to these changes