### PR TITLE
Forbid the deduct transfer temporarily

### DIFF
--- a/__tests__/supertest.js
+++ b/__tests__/supertest.js
@@ -544,7 +544,8 @@ describe('Wallet integration tests', () => {
       tokenB = res.body.token;
     })
 
-    describe(`WalletB:${seed.walletB.name} request a token from ${seed.wallet.name}, should get 202`, () => {
+    //This shouldn't be able to pass anymore, because this is a deduct case, this case do not support yet, check the test for "deduct"
+    describe.skip(`WalletB:${seed.walletB.name} request a token from ${seed.wallet.name}, should get 202`, () => {
 
       beforeEach(async () => {
         const res = await request(server)

--- a/server/models/Wallet.js
+++ b/server/models/Wallet.js
@@ -285,6 +285,7 @@ class Wallet{
    * Transfer some tokens from the sender to receiver
    */
   async transfer(sender, receiver, tokens){
+    await this.checkDeduct(sender, receiver);
     //check tokens belong to sender
     for(const token of tokens){
       if(!await token.belongsTo(sender)){
@@ -603,6 +604,21 @@ class Wallet{
     }
     const result = await this.transferRepository.getByFilter(filter);
     return result;
+  }
+
+  /*
+   * Check if it is deduct, if ture, throw 403, cuz we do not support it yet
+   */
+  async checkDeduct(sender, receiver){
+    if(this._id === sender.getId()){
+      return;
+    }
+    const result = await this.hasControlOver(sender);
+    if(result){
+      return;
+    }else{
+      throw new HttpError(403, "Do not support deduct yet");
+    }
   }
 }
 


### PR DESCRIPTION
Currently, we just allow one-way transfer, means that we can just let people SEND token to others, we still not allow people to deduct tokens from others.

Please check the discussion on Slack: https://greenstand.slack.com/archives/CSN3FGCN7/p1603075626009900

So, we need to disable the deduct operation temporarily.