### PR TITLE
Remove the public schema from the search path

### DIFF
--- a/server/database/knex.js
+++ b/server/database/knex.js
@@ -5,7 +5,7 @@ const knex = require('knex')({
   client: 'pg',
   debug: process.env.NODE_LOG_LEVEL === "debug"? true:false,
   connection,
-  searchPath: ['wallets', 'public'],
+  searchPath: ['wallets'],
   pool: { min:0, max: 100},
 });
 


### PR DESCRIPTION
Are we good to stop referencing the public schema now?