### PR TITLE
DB migration: allow null for wallet password.

### DIFF
--- a/database/migrations/20201127234338-AllowNullPasswordWallet.js
+++ b/database/migrations/20201127234338-AllowNullPasswordWallet.js
@@ -1,0 +1,27 @@
+'use strict';
+
+var dbm;
+var type;
+var seed;
+
+/**
+  * We receive the dbmigrate dependency from dbmigrate initially.
+  * This enables us to not have to rely on NODE_PATH.
+  */
+exports.setup = function(options, seedLink) {
+  dbm = options.dbmigrate;
+  type = dbm.dataType;
+  seed = seedLink;
+};
+
+exports.up = function(db) {
+  return db.changeColumn( 'wallet', 'password', { type: 'string', notNull: false });
+};
+
+exports.down = function(db) {
+  return db.changeColumn( 'wallet', 'password', { type: 'string', notNull: true });
+};
+
+exports._meta = {
+  "version": 1
+};


### PR DESCRIPTION
I have up it locally, but can not do it against the dev db, throwing:
```
[ERROR] AssertionError [ERR_ASSERTION]: ifError got unwanted exception: relation "transaction" already exists
    at /Users/deanchen/work/greenstand/code/treetracker-token-trading-api/node_modules/db-migrate/lib/commands/on-complete.
js:14:14
    at tryCatcher (/Users/deanchen/work/greenstand/code/treetracker-token-trading-api/node_modules/bluebird/js/release/util
.js:16:23)
    at Promise.successAdapter (/Users/deanchen/work/greenstand/code/treetracker-token-trading-api/node_modules/bluebird/js/
release/nodeify.js:22:30)
    at Promise._settlePromise (/Users/deanchen/work/greenstand/code/treetracker-token-trading-api/node_modules/bluebird/js/
release/promise.js:601:21)
    at Promise._settlePromiseCtx (/Users/deanchen/work/greenstand/code/treetracker-token-trading-api/node_modules/bluebird/
js/release/promise.js:641:10)
    at _drainQueueStep (/Users/deanchen/work/greenstand/code/treetracker-token-trading-api/node_modules/bluebird/js/release
/async.js:97:12)
    at _drainQueue (/Users/deanchen/work/greenstand/code/treetracker-token-trading-api/node_modules/bluebird/js/release/asy
nc.js:86:9)
    at Async._drainQueues (/Users/deanchen/work/greenstand/code/treetracker-token-trading-api/node_modules/bluebird/js/rele
ase/async.js:102:5)
    at Immediate.Async.drainQueues [as _onImmediate] (/Users/deanchen/work/greenstand/code/treetracker-token-trading-api/no
de_modules/bluebird/js/release/async.js:15:14)
    at processImmediate (internal/timers.js:456:21)
    at Connection.parseE (/Users/deanchen/work/greenstand/code/treetracker-token-trading-api/node_modules/pg/lib/connection
.js:614:13)
    at Connection.parseMessage (/Users/deanchen/work/greenstand/code/treetracker-token-trading-api/node_modules/pg/lib/conn
ection.js:413:19)
    at TLSSocket.<anonymous> (/Users/deanchen/work/greenstand/code/treetracker-token-trading-api/node_modules/pg/lib/connec
tion.js:129:22)
    at TLSSocket.emit (events.js:315:20)
    at addChunk (_stream_readable.js:295:12)
    at readableAddChunk (_stream_readable.js:271:9)
    at TLSSocket.Readable.push (_stream_readable.js:212:10)
    at TLSWrap.onStreamRead (internal/stream_base_commons.js:186:23)

```

Seems like there is some disorder in the migration record.