### PR TITLE
Forbid management circle/loop.

### DIFF
--- a/server/models/Wallet.js
+++ b/server/models/Wallet.js
@@ -269,9 +269,63 @@ class Wallet{
     if(!trustRelationship){
       throw new HttpError(403, "Have no permission to accept this relationship");
     }
+    await this.checkManageCircle(trustRelationship);
     trustRelationship.state = TrustRelationship.ENTITY_TRUST_STATE_TYPE.trusted;
     const json = await this.trustRepository.update(trustRelationship);
     return json;
+  }
+
+  async checkManageCircle(trustRelationship){
+    const trustRelationshipTrusted = await this.getTrustRelationshipsTrusted();
+    //just manage type of trust relationship
+    if(trustRelationship.type === TrustRelationship.ENTITY_TRUST_TYPE.manage){
+      //if is mange request
+      if(trustRelationship.request_type === TrustRelationship.ENTITY_TRUST_TYPE.manage){
+        if(trustRelationshipTrusted.some(e => {
+          if(
+            (
+              e.type === TrustRelationship.ENTITY_TRUST_TYPE.manage &&
+              e.request_type === TrustRelationship.ENTITY_TRUST_REQUEST_TYPE.manage &&
+              e.actor_entity_id === trustRelationship.target_entity_id &&
+              e.target_entity_id === trustRelationship.actor_entity_id
+            ) || (
+              e.type === TrustRelationship.ENTITY_TRUST_TYPE.manage &&
+              e.request_type === TrustRelationship.ENTITY_TRUST_REQUEST_TYPE.yield &&
+              e.actor_entity_id === trustRelationship.actor_entity_id &&
+              e.target_entity_id === trustRelationship.target_entity_id
+            )
+          ){
+            return true;
+          }else{
+            return false;
+          }
+        })){
+          throw new HttpError(403, "Operation forbidden, because this would lead to a management circle");
+        }
+      }else if(trustRelationship.request_type === TrustRelationship.ENTITY_TRUST_REQUEST_TYPE.yield){
+        if(trustRelationshipTrusted.some(e => {
+          if(
+            (
+              e.type === TrustRelationship.ENTITY_TRUST_TYPE.manage &&
+              e.request_type === TrustRelationship.ENTITY_TRUST_REQUEST_TYPE.yield &&
+              e.actor_entity_id === trustRelationship.target_entity_id &&
+              e.target_entity_id === trustRelationship.actor_entity_id
+            ) || (
+              e.type === TrustRelationship.ENTITY_TRUST_TYPE.manage &&
+              e.request_type === TrustRelationship.ENTITY_TRUST_REQUEST_TYPE.manage &&
+              e.actor_entity_id === trustRelationship.actor_entity_id &&
+              e.target_entity_id === trustRelationship.target_entity_id
+            )
+          ){
+            return true;
+          }else{
+            return false;
+          }
+        })){
+          throw new HttpError(403, "Operation forbidden, because this would lead to a management circle");
+        }
+      }
+    }
   }
 
   /*

--- a/server/models/Wallet.spec.js
+++ b/server/models/Wallet.spec.js
@@ -1113,4 +1113,99 @@ describe("Wallet", () => {
     });
   });
 
+  describe("checkManageRecycle", () => {
+
+    it("A manage B, now B request to manage A, should throw error", async () => {
+      const walletA = new Wallet(1);
+      const walletB = new Wallet(2);
+      const trustRelationshipTrusted = {
+        id: 1,
+        type: TrustRelationship.ENTITY_TRUST_TYPE.manage,
+        request_type: TrustRelationship.ENTITY_TRUST_REQUEST_TYPE.manage,
+        actor_entity_id: walletA.getId(),
+        target_entity_id: walletB.getId(),
+      }
+      const trustRelationshipRequested = {
+        id: 1,
+        type: TrustRelationship.ENTITY_TRUST_TYPE.manage,
+        request_type: TrustRelationship.ENTITY_TRUST_REQUEST_TYPE.manage,
+        actor_entity_id: walletB.getId(),
+        target_entity_id: walletA.getId(),
+      }
+      sinon.stub(Wallet.prototype, "getTrustRelationshipsTrusted").resolves([trustRelationshipTrusted]);
+      await jestExpect(async () => {
+        await walletA.checkManageCircle(trustRelationshipRequested);
+      }).rejects.toThrow(/circle/);
+    });
+
+    it("A manage B, now A request to yield B, should throw error", async () => {
+      const walletA = new Wallet(1);
+      const walletB = new Wallet(2);
+      const trustRelationshipTrusted = {
+        id: 1,
+        type: TrustRelationship.ENTITY_TRUST_TYPE.manage,
+        request_type: TrustRelationship.ENTITY_TRUST_REQUEST_TYPE.manage,
+        actor_entity_id: walletA.getId(),
+        target_entity_id: walletB.getId(),
+      }
+      const trustRelationshipRequested = {
+        id: 1,
+        type: TrustRelationship.ENTITY_TRUST_TYPE.manage,
+        request_type: TrustRelationship.ENTITY_TRUST_REQUEST_TYPE.yield,
+        actor_entity_id: walletA.getId(),
+        target_entity_id: walletB.getId(),
+      }
+      sinon.stub(Wallet.prototype, "getTrustRelationshipsTrusted").resolves([trustRelationshipTrusted]);
+      await jestExpect(async () => {
+        await walletA.checkManageCircle(trustRelationshipRequested);
+      }).rejects.toThrow(/circle/);
+    });
+
+    it("A yield B, now B request to yield A, should throw error", async () => {
+      const walletA = new Wallet(1);
+      const walletB = new Wallet(2);
+      const trustRelationshipTrusted = {
+        id: 1,
+        type: TrustRelationship.ENTITY_TRUST_TYPE.manage,
+        request_type: TrustRelationship.ENTITY_TRUST_REQUEST_TYPE.yield,
+        actor_entity_id: walletA.getId(),
+        target_entity_id: walletB.getId(),
+      }
+      const trustRelationshipRequested = {
+        id: 1,
+        type: TrustRelationship.ENTITY_TRUST_TYPE.manage,
+        request_type: TrustRelationship.ENTITY_TRUST_REQUEST_TYPE.yield,
+        actor_entity_id: walletB.getId(),
+        target_entity_id: walletA.getId(),
+      }
+      sinon.stub(Wallet.prototype, "getTrustRelationshipsTrusted").resolves([trustRelationshipTrusted]);
+      await jestExpect(async () => {
+        await walletA.checkManageCircle(trustRelationshipRequested);
+      }).rejects.toThrow(/circle/);
+    });
+
+    it("A yield B, now A request to manage B, should throw error", async () => {
+      const walletA = new Wallet(1);
+      const walletB = new Wallet(2);
+      const trustRelationshipTrusted = {
+        id: 1,
+        type: TrustRelationship.ENTITY_TRUST_TYPE.manage,
+        request_type: TrustRelationship.ENTITY_TRUST_REQUEST_TYPE.yield,
+        actor_entity_id: walletA.getId(),
+        target_entity_id: walletB.getId(),
+      }
+      const trustRelationshipRequested = {
+        id: 1,
+        type: TrustRelationship.ENTITY_TRUST_TYPE.manage,
+        request_type: TrustRelationship.ENTITY_TRUST_REQUEST_TYPE.manage,
+        actor_entity_id: walletA.getId(),
+        target_entity_id: walletB.getId(),
+      }
+      sinon.stub(Wallet.prototype, "getTrustRelationshipsTrusted").resolves([trustRelationshipTrusted]);
+      await jestExpect(async () => {
+        await walletA.checkManageCircle(trustRelationshipRequested);
+      }).rejects.toThrow(/circle/);
+    });
+  });
+
 });


### PR DESCRIPTION
@deepwinter the circle management is a bit too complicated for the logic, I am scared to bring it to reality, and let the unexpected wrong state of DB to crash the whole system,  so I added the rule to forbid a loop management for the time being. Look at the logic, even trying to find out the loop is difficult, thinking about the type, manage, yield, different direction, lost my mind.. :D 

Resolve #104 