### PR TITLE
Get tokens related to a transfer

### DIFF
--- a/docs/api/spec/treetracker-token-api.yaml
+++ b/docs/api/spec/treetracker-token-api.yaml
@@ -265,6 +265,26 @@ paths:
       deprecated: false
   
   
+  /transfers/{transfer_id}:
+    get:
+      tags:
+      - Transfers
+      summary: 'Get information of a single transfer'
+      parameters:
+        - $ref: '#/components/parameters/treetrackerApiKeyParam'
+        - $ref: '#/components/parameters/contentTypeJsonHeader'
+        - name: transfer_id
+          in: path
+          description: ''
+          required: true
+          schema:
+            type: integer
+            format: int32
+      responses:
+        '200':
+          description: ''
+        '401':
+          $ref: '#/components/responses/UnauthorizedError'
   
   /transfers/{transfer_id}:
     delete:
@@ -368,6 +388,28 @@ paths:
           description: ''
         '401':
           $ref: '#/components/responses/UnauthorizedError'
+
+  /transfers/{transfer_id}/tokens:
+    get:
+      tags:
+      - Transfers
+      summary: 'Get all tokens linked to a single transfer'
+      parameters:
+        - $ref: '#/components/parameters/treetrackerApiKeyParam'
+        - $ref: '#/components/parameters/contentTypeJsonHeader'
+        - name: transfer_id
+          in: path
+          description: ''
+          required: true
+          schema:
+            type: integer
+            format: int32
+      responses:
+        '200':
+          description: ''
+        '401':
+          $ref: '#/components/responses/UnauthorizedError'
+
   /events:
     get:
       tags: 

--- a/docs/api/spec/treetracker-token-api.yaml
+++ b/docs/api/spec/treetracker-token-api.yaml
@@ -265,6 +265,7 @@ paths:
       deprecated: false
   
   
+  
   /transfers/{transfer_id}:
     get:
       tags:
@@ -285,8 +286,6 @@ paths:
           description: ''
         '401':
           $ref: '#/components/responses/UnauthorizedError'
-  
-  /transfers/{transfer_id}:
     delete:
       tags:
       - Transfers

--- a/server/models/Wallet.js
+++ b/server/models/Wallet.js
@@ -850,6 +850,32 @@ class Wallet{
     return result;
   }
 
+  async getTransferById(id){
+    const transfers = await this.getTransfers();
+    const transfer = transfers.reduce((a,c) => {
+      if(c.id === id){
+        return c;
+      }else{
+        return a;
+      }
+    }, undefined);
+    if(!transfer){
+      throw new HttpError(404, "Can not find this transfer or it is related to this wallet");
+    }
+    return transfer;
+  }
+
+  async getTokensByTransferId(id){
+    const transfer = await this.getTransferById(id);
+    let tokens;
+    if(transfer.state === Transfer.STATE.completed){
+      tokens = await this.tokenService.getTokensByTransferId(transfer.id);
+    }else{
+      tokens = await this.tokenService.getTokensByPendingTransferId(transfer.id);
+    }
+    return tokens;
+  }
+
   /*
    * Check if it is deduct, if ture, throw 403, cuz we do not support it yet
    */

--- a/server/models/Wallet.spec.js
+++ b/server/models/Wallet.spec.js
@@ -1177,4 +1177,52 @@ describe("Wallet", () => {
     });
   });
 
+  describe("getTransferById", () => {
+
+    it("Successfully", async () => {
+      sinon.stub(Wallet.prototype, "getTransfers").resolves([{
+        id: 1,
+      }]);
+      const transfer = await wallet.getTransferById(1);
+      expect(transfer).property("id").eq(1);
+    });
+
+    it("Not fond", async () => {
+      sinon.stub(Wallet.prototype, "getTransfers").resolves([]);
+      await jestExpect(async () => {
+        await wallet.getTransferById(1);
+      }).rejects.toThrow(/not find/);
+    });
+  });
+
+  describe("getTokensByTransferId", () => {
+
+    it("Completed transfer", async () => {
+      const transfer = { 
+        id: 1,
+        state: Transfer.STATE.completed,
+      };
+      const token = new Token(1);
+      sinon.stub(Wallet.prototype, "getTransferById").resolves(transfer);
+      const fn = sinon.stub(TokenService.prototype, "getTokensByTransferId").resolves([token]);
+      const tokens = await wallet.getTokensByTransferId(1);
+      expect(tokens).lengthOf(1);
+      expect(fn).calledWith(1);
+    });
+
+    it("Pending/requested transfer", async () => {
+      const transfer = { 
+        id: 1,
+        state: Transfer.STATE.pending,
+      };
+      const token = new Token(1);
+      sinon.stub(Wallet.prototype, "getTransferById").resolves(transfer);
+      const fn = sinon.stub(TokenService.prototype, "getTokensByPendingTransferId").resolves([token]);
+      const tokens = await wallet.getTokensByTransferId(1);
+      expect(tokens).lengthOf(1);
+      expect(fn).calledWith(1);
+    });
+
+  });
+
 });

--- a/server/routes/transferRouter.js
+++ b/server/routes/transferRouter.js
@@ -299,4 +299,49 @@ transferRouter.get("/",
   })
 );
 
+transferRouter.get('/:transfer_id',
+  helper.apiKeyHandler,
+  helper.verifyJWTHandler,
+  helper.handlerWrapper(async (req, res) => {
+    Joi.assert(
+      req.params,
+      Joi.object({
+        transfer_id: Joi.number().required(),
+      })
+    );
+    const session = new Session();
+    const walletService = new WalletService(session);
+    const transferService = new TransferService(session);
+    const walletLogin = await walletService.getById(res.locals.wallet_id);
+    const transferObject = await walletLogin.getTransferById(parseInt(req.params.transfer_id));
+    const transferJson = await transferService.convertToResponse(transferObject);
+    res.status(200).json(transferJson);
+  })
+);
+
+transferRouter.get('/:transfer_id/tokens',
+  helper.apiKeyHandler,
+  helper.verifyJWTHandler,
+  helper.handlerWrapper(async (req, res) => {
+    Joi.assert(
+      req.params,
+      Joi.object({
+        transfer_id: Joi.number().required(),
+      })
+    );
+    const session = new Session();
+    const walletService = new WalletService(session);
+    const walletLogin = await walletService.getById(res.locals.wallet_id);
+    const tokens = await walletLogin.getTokensByTransferId(parseInt(req.params.transfer_id));
+    const tokensJson = [];
+    for(const token of tokens){
+      const json = await token.toJSON();
+      tokensJson.push(json);
+    }
+    res.status(200).json({
+      tokens: tokensJson,
+    });
+  })
+);
+
 module.exports = transferRouter;

--- a/server/routes/transferRouter.spec.js
+++ b/server/routes/transferRouter.spec.js
@@ -279,7 +279,7 @@ describe("transferRouter", () => {
     });
   });
 
-  describe.only("GET /{transfer_id}/tokens", () => {
+  describe("GET /{transfer_id}/tokens", () => {
 
     it("Successfully", async () => {
       const wallet = new Wallet(1);

--- a/server/routes/transferRouter.spec.js
+++ b/server/routes/transferRouter.spec.js
@@ -261,4 +261,39 @@ describe("transferRouter", () => {
     });
   });
 
+  describe("GET /{transfer_id}", () => {
+
+    it("Successfully", async () => {
+      const wallet = new Wallet(1);
+      const transfer = {id:2};
+      const fn = sinon.stub(WalletService.prototype, "getById").resolves(wallet);
+      const fn2 = sinon.stub(Wallet.prototype, "getTransferById").resolves(transfer);
+      const fn3 = sinon.stub(TransferService.prototype, "convertToResponse").resolves(transfer);
+      const res = await request(app)
+        .get("/2");
+      expect(fn).calledWith(1);
+      expect(fn2).calledWith(2);
+      expect(fn3).calledWith(transfer);
+      expect(res).property("statusCode").eq(200);
+      expect(res.body).property("id").eq(2);
+    });
+  });
+
+  describe.only("GET /{transfer_id}/tokens", () => {
+
+    it("Successfully", async () => {
+      const wallet = new Wallet(1);
+      const transfer = {id:2};
+      const token = new Token({id:3});
+      const fn = sinon.stub(WalletService.prototype, "getById").resolves(wallet);
+      const fn2 = sinon.stub(Wallet.prototype, "getTokensByTransferId").resolves([token]);
+      const res = await request(app)
+        .get("/2/tokens");
+      expect(fn).calledWith(1);
+      expect(fn2).calledWith(2);
+      expect(res).property("statusCode").eq(200);
+      expect(res.body).property("tokens").lengthOf(1);
+    });
+  })
+
 });

--- a/server/services/TokenService.js
+++ b/server/services/TokenService.js
@@ -1,5 +1,6 @@
 const Token = require("../models/Token");
 const TokenRepository = require("../repositories/TokenRepository");
+const TransactionRepository = require("../repositories/TransactionRepository");
 const expect = require("expect-runtime");
 
 class TokenService{
@@ -7,6 +8,7 @@ class TokenService{
   constructor(session){
     this._session =  session
     this.tokenRepository = new TokenRepository(session);
+    this.transactionRepository = new TransactionRepository(session);
     const WalletService  = require("../services/WalletService");
     this.walletService = new WalletService(session);
   }
@@ -95,6 +97,15 @@ class TokenService{
       result.receiver_wallet = await json.name;
     }
     return result;
+  }
+
+  async getTokensByTransferId(transferId){
+    const result = await this.transactionRepository.getByFilter({
+      transfer_id: transferId,
+    });
+    return result.map(object => {
+      return new Token(object, this._session);
+    });
   }
 
 }

--- a/server/services/TokenService.js
+++ b/server/services/TokenService.js
@@ -103,9 +103,12 @@ class TokenService{
     const result = await this.transactionRepository.getByFilter({
       transfer_id: transferId,
     });
-    return result.map(object => {
-      return new Token(object, this._session);
-    });
+    const tokens = [];
+    for(const r of result){
+      const token = await this.getById(r.token_id);
+      tokens.push(token);
+    }
+    return tokens;
   }
 
 }

--- a/server/services/TokenService.spec.js
+++ b/server/services/TokenService.spec.js
@@ -87,12 +87,19 @@ describe("Token", () => {
   describe("getTokensByTransferId", () => {
 
     it("Successfuly", async () => {
-      const fn = sinon.stub(TransactionRepository.prototype, "getByFilter").resolves([{id:1}]);
+      const token = new Token({id:2});
+      const transaction = {
+        id: 1,
+        token_id: 2,
+      };
+      const fn = sinon.stub(TransactionRepository.prototype, "getByFilter").resolves([transaction]);
+      const fn2 = sinon.stub(TokenService.prototype, "getById").resolves(token);
       const tokens = await tokenService.getTokensByTransferId(1);
-      expect(tokens).lengthOf(1);
       expect(fn).calledWith({
         transfer_id: 1,
       })
+      expect(fn2).calledWith(2);
+      expect(tokens).lengthOf(1);
     });
   });
 

--- a/server/services/TokenService.spec.js
+++ b/server/services/TokenService.spec.js
@@ -11,6 +11,7 @@ const Wallet = require("../models/Wallet");
 const Token = require("../models/Token");
 const WalletService = require("../services/WalletService");
 const Session = require("../models/Session");
+const TransactionRepository = require("../repositories/TransactionRepository");
 
 describe("Token", () => {
   let tokenService;
@@ -82,5 +83,18 @@ describe("Token", () => {
     expect(result).property("sender_wallet").eq("testName");
     expect(result).property("receiver_wallet").eq("testName");
   });
+
+  describe("getTokensByTransferId", () => {
+
+    it("Successfuly", async () => {
+      const fn = sinon.stub(TransactionRepository.prototype, "getByFilter").resolves([{id:1}]);
+      const tokens = await tokenService.getTokensByTransferId(1);
+      expect(tokens).lengthOf(1);
+      expect(fn).calledWith({
+        transfer_id: 1,
+      })
+    });
+  });
+
 
 });


### PR DESCRIPTION
Resolve #139 

Feature: 
  * GET /transfers/{id}/tokens to get all tokens.
  * Also added a mother endpoint I think is necessary:  GET /transfers/{id} to get info of a single transfer
  * Modified yaml file.

Please re-import the yaml to find the new endpoint.
