### PR TITLE
fix: unit test to remove unnecessary visit to the DB

### DIFF
--- a/server/routes/transferRouter.spec.js
+++ b/server/routes/transferRouter.spec.js
@@ -25,6 +25,8 @@ describe("transferRouter", () => {
   }
 
   beforeEach(() => {
+    //mock session, note, this will impact all tests, when unit test, the session is a totally fake stuff
+    sinon.stub(Session.prototype);
     sinon.stub(ApiKeyService.prototype, "check");
     sinon.stub(JWTService.prototype, "verify").returns({
       id: walletLogin.id,


### PR DESCRIPTION
Mainly this problem is that in the unit tests, there are some tests accidentally connecting to DB.