### PR TITLE
fix: Db migration k8s

### DIFF
--- a/deployment/kustomize/kustomization.yaml
+++ b/deployment/kustomize/kustomization.yaml
@@ -3,3 +3,5 @@ resources:
 - treetracker-wallet-api-mapping.yaml
 - treetracker-wallet-api-service.yaml
 - treetracker-wallet-api-db-migration-job.yaml
+- treetracker-wallet-api-clusterrole.yaml
+- treetracker-wallet-api-clusterrolebinding.yaml

--- a/deployment/treetracker-wallet-api-clusterrole.yaml
+++ b/deployment/treetracker-wallet-api-clusterrole.yaml
@@ -1,0 +1,11 @@
+apiVersion: rbac.authorization.k8s.io/v1beta1
+kind: ClusterRole
+metadata:
+  name: k8s-wait-for
+rules:
+- apiGroups: [""]
+  resources: ["services","pods","jobs"]
+  verbs: ["get","watch","list"]
+- apiGroups: ["batch"]
+  resources: ["services","pods","jobs"]
+  verbs: ["get","watch","list"]

--- a/deployment/treetracker-wallet-api-clusterrolebinding.yaml
+++ b/deployment/treetracker-wallet-api-clusterrolebinding.yaml
@@ -1,0 +1,12 @@
+apiVersion: rbac.authorization.k8s.io/v1beta1
+kind: ClusterRoleBinding
+metadata:
+  name: k8s-wait-for
+subjects:
+  - kind: ServiceAccount
+    name: default
+    namespace: wallet-api
+roleRef:
+  kind: ClusterRole
+  name: k8s-wait-for
+  apiGroup: rbac.authorization.k8s.io


### PR DESCRIPTION
Add clusterrole and clusterrolebinding so that k8s-wait init container can run (needs these permissions to scan for completed jobs in its namespace)

