### PR TITLE
Run e2e against local server

### DIFF
--- a/README.md
+++ b/README.md
@@ -439,6 +439,26 @@ In order to efficiently run our integration tests, we rely on automated database
 npm run test-seedDB
 ```
 
+## End to End test
+
+To run the test:
+
+```
+npm run test-e2e
+```
+
+To run the test locally against the local code/server:
+
+```
+npm run test-e2e-locally
+```
+
+NOTE running e2e needs to set up some env variables like the Database connection, we can attach the env variables on the CLI command line:
+
+```
+> DB_HOST=localhost DB_USERNAME=postgres DB_PORT=23720 DB_PASSWORD=*** DB_NAME=treetracker DB_SCHEMA=public npm run test-e2e-locally
+```
+
 ## Suggestion about how to run tests when developing
 
 There is a command in the `package.json`:

--- a/__tests__/e2e/config.js
+++ b/__tests__/e2e/config.js
@@ -1,6 +1,10 @@
 require("dotenv").config();
 
-const request = require("supertest")(`https://${process.env.ENVIRONMENT}-k8s.treetracker.org/wallet`);
+const server = process.env.RUN_E2E_LOCALLY ?
+    require("../../server/app")
+  : 
+    `https://${process.env.ENVIRONMENT}-k8s.treetracker.org/wallet`;
+const request = require("supertest")(server);
 const expect = require("chai").expect;
 const responseStatus = require("http-status-codes");
 const assert = require("./libs/assertionLibrary.js");

--- a/__tests__/e2e/database/knex.js
+++ b/__tests__/e2e/database/knex.js
@@ -8,7 +8,8 @@ const knexConfig = {
     port: process.env.DB_PORT,
     password: process.env.DB_PASSWORD,
     database: process.env.DB_NAME,
-    ssl: true,
+    // eslint-disable-next-line 
+    ssl: process.env.DB_SSL === "false" ? false : true,
   },
   debug: false,
   searchPath: [process.env.DB_SCHEMA],

--- a/package.json
+++ b/package.json
@@ -22,6 +22,7 @@
     "test-watch": "NODE_ENV=test NODE_LOG_LEVEL=info mocha -r dotenv/config dotenv_config_path=.env.test --timeout 10000 --require co-mocha -w -b --ignore './server/repositories/**/*.spec.js'  './server/setup.js' './server/**/*.spec.js' './__tests__/seed.spec.js' './__tests__/supertest.js'",
     "test-watch-debug": "NODE_ENV=test NODE_LOG_LEVEL=debug DOTENV_CONFIG_PATH=.env.test mocha -r dotenv/config --timeout 10000 --require co-mocha -w -b --ignore './server/repositories/**/*.spec.js'  './server/setup.js' './server/**/*.spec.js' './__tests__/seed.spec.js' './__tests__/**/*.spec.js'",
     "test-e2e": "NODE_TLS_REJECT_UNAUTHORIZED='0' mocha --config ./__tests__/e2e/.mocharc.js",
+    "test-e2e-locally": "RUN_E2E_LOCALLY=true DB_SSL=false NODE_ENV=test NODE_LOG_LEVEL=debug NODE_TLS_REJECT_UNAUTHORIZED='0' mocha --config ./__tests__/e2e/.mocharc.js ./server/setup.js",
     "prettier-fix": "prettier ./ --write",
     "db-migrate-ci": "cd database; db-migrate up",
     "start-db": "docker-compose up"


### PR DESCRIPTION
For convenience when developing, add command to run e2e against current code.
Having no impact to current e2e test.