### PR TITLE
/transfers returns pagination fields

### DIFF
--- a/docs/api/spec/treetracker-wallet-api-v1-10.yaml
+++ b/docs/api/spec/treetracker-wallet-api-v1-10.yaml
@@ -47,9 +47,9 @@ paths:
             type: integer
             format: int32
             example: 100
-        - name: start
+        - name: offset
           in: query
-          description: 'Where does the list start, 1 means start from the beginning of the list'
+          description: 'Where does the list start, 0 means start from the beginning of the list'
           required: false
           style: form
           explode: true
@@ -57,6 +57,7 @@ paths:
             type: integer
             format: int32
             example: 1
+            default: 0
         - name: wallet
           description: Wallet id or name can be specified if the authenticated wallet manages other wallets.  The default is to return tokens matching the authenticated wallet
           in: query
@@ -118,9 +119,9 @@ paths:
             format: int32
             example: 100
             default: 100
-        - name: start
+        - name: offset
           in: query
-          description: 'Where does the list start, 1 means start from the beginning of the list'
+          description: 'Where does the list start, 0 means start from the beginning of the list'
           required: false
           style: form
           explode: true
@@ -128,7 +129,7 @@ paths:
             type: integer
             format: int32
             example: 1
-            default: 1
+            default: 0
       responses:
         '200':
           description: ''
@@ -237,9 +238,9 @@ paths:
             type: integer
             format: int32
             example: 100
-        - name: start
+        - name: offset
           in: query
-          description: 'Where does the list start, 1 means start from the beginning of the list'
+          description: 'Where does the list start, 0 means start from the beginning of the list'
           required: false
           style: form
           explode: true
@@ -247,9 +248,25 @@ paths:
             type: integer
             format: int32
             example: 1
+            default: 0
       responses:
         '200':
           description: Return array of matching transfers
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  transfers:
+                    type: array
+                    items:
+                      $ref: '#/components/schemas/transferItem'
+                  limit:
+                    type: integer
+                  offset:
+                    type: integer
+                  total:
+                    type: integer
         '401':
           $ref: '#/components/responses/UnauthorizedError'
   '/tokens/{token_uuid}/transactions':
@@ -278,9 +295,9 @@ paths:
             type: integer
             format: int32
             example: 100
-        - name: start
+        - name: offset
           in: query
-          description: 'Where does the list start, 1 means start from the beginning of the list'
+          description: 'Where does the list start, 0 means start from the beginning of the list'
           required: false
           style: form
           explode: true
@@ -288,6 +305,7 @@ paths:
             type: integer
             format: int32
             example: 1
+            default: 0
       responses:
         '200':
           description: ''
@@ -313,6 +331,10 @@ paths:
       responses:
         '200':
           description: ''
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/transferItem'
         '401':
           $ref: '#/components/responses/UnauthorizedError'
     delete:
@@ -429,9 +451,9 @@ paths:
             type: integer
             format: int32
             example: 100
-        - name: start
+        - name: offset
           in: query
-          description: 'Where does the list start, 1 means start from the beginning of the list'
+          description: 'Where does the list start, 0 means start from the beginning of the list'
           required: false
           style: form
           explode: true
@@ -439,6 +461,7 @@ paths:
             type: integer
             format: int32
             example: 1
+            default: 0
       responses:
         '200':
           description: ''
@@ -462,9 +485,9 @@ paths:
             type: integer
             format: int32
             example: 100
-        - name: start
+        - name: offset
           in: query
-          description: 'Where does the list start, 1 means start from the beginning of the list'
+          description: 'Where does the list start, 0 means start from the beginning of the list'
           required: false
           style: form
           explode: true
@@ -472,6 +495,7 @@ paths:
             type: integer
             format: int32
             example: 1
+            default: 0
         - name: state
           in: query
           description: Filter by state of the trust relationship
@@ -684,7 +708,7 @@ components:
           type: array
           items:
             $ref: '#/components/schemas/tokenItem'
-    tokenItems:
+    tokenItem:
       title: Token Item
       type: object
       properties:
@@ -742,17 +766,109 @@ components:
           type: array
           items:
             $ref: '#/components/schemas/walletItem'
+        total:
+          type: integer
+          description: total count of wallets satisfying the query condition
+          example: 1
+        query:
+          type: object
+          properties:
+            offset:
+              type: integer
+              example: 0
+            limit:
+              type: integer
+              example: 5
     walletItem:
       title: Wallet Details
       properties:
-        wallet:
+        id:
           type: string
-        email:
+          format: uuid
+          example: 482bf306-30c7-4cea-833a-1cdda3d96573
+        name:
           type: string
-        phone:
+          example: test11
+        logo_url:
           type: string
+          format: url
+          example: https://www.placehold.co/192x192
+        created_at:
+          type: string
+          format: date-time
+          example: 2023-08-08T06:28:39.766Z
         tokens_in_wallet:
           type: integer
+          example: 12
+    transferItem:
+      title: Transfer Details
+      properties:
+        id:
+          type: string
+          format: uuid
+          description: Transfer ID
+          example: cf0ce129-8c12-45cf-b914-a8f1cb6b7dc5
+        type:
+          type: string
+          enum:
+            - send
+            - deduct
+            - managed
+          description: Transfer type
+          example: send
+        parameters:
+          type: object
+          oneOf:
+            - properties:
+                bundle:
+                  type: object
+                  properties:
+                    bundleSize:
+                      type: integer
+                      description: Number of tokens associated with the transfer
+                      example: 2
+                  required:
+                    - bundleSize
+            - properties:
+                tokens:
+                  type: array
+                  items:
+                    $ref: '#/components/schemas/tokenItem'
+        state:
+          type: string
+          enum:
+            - pending
+            - completed
+            - requested
+            - cancelled
+            - failed
+          example: completed
+        created_at:
+          type: string
+          format: date-time
+          example: 2023-08-02T21:46:35.134Z
+        closed_at:
+          type: string
+          format: date-time
+          example: 2023-08-02T21:46:35.134Z
+        active:
+          type: boolean
+          example: true
+        claim:
+          type: boolean
+          example: false
+        originating_wallet:
+          type: string
+          example: testuser
+        source_wallet:
+          type: string
+          example: testuser
+        destination_wallet:
+          type: string
+          example: wallet22
+        token_count:
+          type: integer
+          example: 1
     transferrequest:
       title: transferrequest
       oneOf:
@@ -843,35 +959,35 @@ components:
       properties:
         id:
           type: string
+          format: uuid
           description: The unique ID for this transfer
         originating_wallet:
           type: string
+          example: johnwallet1
         source_wallet:
           type: string
+          example: planeter
         destination_wallet:
           type: string
+          example: just.a.guy
         type:
           type: string
           description: 'the type of transfer.  send, deduct, or managed. the value is computed by the server based on the submitted request'
+          example: send
         parameters:
           $ref: '#/components/schemas/requestBundleRequestParameters'
         state:
           type: string
           description: 'the state of the transfer.  requested, pending, completed, cancelled, or failed'
+          example:  completed
         created_at:
           type: string
+          format: date-time
+          example: 2020-07-09T00:41:49+00:00
         closed_at:
           type: string
-      example:
-        originating_wallet: johnwallet1
-        source_wallet: planeter
-        destination_wallet: just.a.guy
-        type: send
-        parameters:
-          $ref: '#/components/schemas/requestBundleRequestParameters'
-        state: completed
-        created_at: '2020-07-09T00:41:49+00:00'
-        closed_at: '2020-07-09T00:41:49+00:00'
+          format: date-time
+          example: 2020-07-09T00:41:49+00:00
     sendRequestPendingResponse:
       title: sendRequestPendingResponse
     sendBundleRequest:

--- a/server/handlers/transferHandler.spec.js
+++ b/server/handlers/transferHandler.spec.js
@@ -40,11 +40,13 @@ describe('transferRouter', () => {
 
     const getByFilterStub = sinon
       .stub(TransferService.prototype, 'getByFilter')
-      .resolves([{ id: token0Id, state: TransferEnums.STATE.completed }]);
+      .resolves({transfers:[{id: token0Id, state: TransferEnums.STATE.completed}]});
 
     const res = await request(app).get(
       '/transfers?limit=3&wallet=testWallet&offset=5',
     );
+
+    console.log('RESULT', res.body)
     expect(res.body.transfers).lengthOf(1);
     expect(res.body.transfers[0].id).eql(token0Id);
     expect(res.body.transfers[0].state).eql(TransferEnums.STATE.completed);

--- a/server/handlers/transferHandler.spec.js
+++ b/server/handlers/transferHandler.spec.js
@@ -46,7 +46,6 @@ describe('transferRouter', () => {
       '/transfers?limit=3&wallet=testWallet&offset=5',
     );
 
-    console.log('RESULT', res.body)
     expect(res.body.transfers).lengthOf(1);
     expect(res.body.transfers[0].id).eql(token0Id);
     expect(res.body.transfers[0].state).eql(TransferEnums.STATE.completed);

--- a/server/handlers/transferHandler/index.js
+++ b/server/handlers/transferHandler/index.js
@@ -84,7 +84,7 @@ const transferGet = async (req, res) => {
       +t.parameters?.bundle?.bundleSize || +t.parameters?.tokens?.length,
   }));
 
-  res.status(200).json({ transfers: modifiedTransfers, limit, offset, total:count });
+  res.status(200).json({ transfers: modifiedTransfers, query: {...params, limit, offset}, total:count });
 };
 
 const transferIdGet = async (req, res) => {

--- a/server/handlers/transferHandler/index.js
+++ b/server/handlers/transferHandler/index.js
@@ -95,7 +95,14 @@ const transferIdGet = async (req, res) => {
     req.params.transfer_id,
     req.wallet_id,
   );
-  res.json(result);
+
+  const modifiedTransfer = {
+    ...result,
+    token_count:
+        +result.parameters?.bundle?.bundleSize || +result.parameters?.tokens?.length,
+  }
+
+  res.json(modifiedTransfer);
 };
 
 const transferIdTokenGet = async (req, res) => {

--- a/server/handlers/transferHandler/index.js
+++ b/server/handlers/transferHandler/index.js
@@ -73,7 +73,10 @@ const transferGet = async (req, res) => {
   await transferGetQuerySchema.validateAsync(req.query, { abortEarly: false });
 
   const transferService = new TransferService();
-  const transfers = await transferService.getByFilter(req.query, req.wallet_id);
+
+  const { limit = 200, offset = 0, ...params } = req.query;
+
+  const {transfers, count} = await transferService.getByFilter({...params, limit, offset}, req.wallet_id);
 
   const modifiedTransfers = transfers.map((t) => ({
     ...t,
@@ -81,7 +84,7 @@ const transferGet = async (req, res) => {
       +t.parameters?.bundle?.bundleSize || +t.parameters?.tokens?.length,
   }));
 
-  res.status(200).json({ transfers: modifiedTransfers });
+  res.status(200).json({ transfers: modifiedTransfers, limit, offset, total:count });
 };
 
 const transferIdGet = async (req, res) => {

--- a/server/handlers/walletHandler.spec.js
+++ b/server/handlers/walletHandler.spec.js
@@ -48,6 +48,7 @@ describe('walletRouter', () => {
         .resolves({ wallets: [{ id: walletId }], count: 1 });
 
       const res = await request(app).get('/wallets?limit=2');
+
       expect(res).property('statusCode').eq(200);
       expect(res.body.wallets).lengthOf(1);
       expect(res.body.wallets[0]).property('id').eq(walletId);

--- a/server/models/Transfer.js
+++ b/server/models/Transfer.js
@@ -26,12 +26,12 @@ class Transfer {
     return transferObjectCopy;
   }
 
-  async getByFilter(filter, limitOptions, getCount) {
-    const {count, result} = await this._transferRepository.getByFilter(
+  async getByFilter(filter, limitOptions) {
+    const {result, count} = await this._transferRepository.getByFilter(
       filter,
       limitOptions,
-      getCount
     );
+
 
     const transfers =  result.map((t) => this.constructor.removeWalletIds(t));
 
@@ -39,7 +39,7 @@ class Transfer {
   }
 
   async getById({ transferId, walletLoginId }) {
-    const transfers = await this.getTransfers({ walletLoginId, transferId });
+    const {transfers} = await this.getTransfers({ walletLoginId, transferId });
     return transfers[0];
   }
 
@@ -65,7 +65,6 @@ class Transfer {
     transferId,
     before,
     after,
-    getCount
   }) {
     const filter = {
       and: [],
@@ -98,7 +97,7 @@ class Transfer {
     if (after) {
       filter.and.push({ after: { 'transfer.created_at': after } });
     }
-    return this.getByFilter(filter, { offset, limit }, getCount);
+    return this.getByFilter(filter, { offset, limit });
   }
 
   /*

--- a/server/models/Transfer.js
+++ b/server/models/Transfer.js
@@ -26,13 +26,16 @@ class Transfer {
     return transferObjectCopy;
   }
 
-  async getByFilter(filter, limitOptions) {
-    const transfers = await this._transferRepository.getByFilter(
+  async getByFilter(filter, limitOptions, getCount) {
+    const {count, result} = await this._transferRepository.getByFilter(
       filter,
       limitOptions,
+      getCount
     );
 
-    return transfers.map((t) => this.constructor.removeWalletIds(t));
+    const transfers =  result.map((t) => this.constructor.removeWalletIds(t));
+
+    return { transfers, count }
   }
 
   async getById({ transferId, walletLoginId }) {
@@ -56,12 +59,13 @@ class Transfer {
   async getTransfers({
     state,
     walletId,
-    offset = 0,
+    offset,
     limit,
     walletLoginId,
     transferId,
     before,
     after,
+    getCount
   }) {
     const filter = {
       and: [],
@@ -94,7 +98,7 @@ class Transfer {
     if (after) {
       filter.and.push({ after: { 'transfer.created_at': after } });
     }
-    return this.getByFilter(filter, { offset, limit });
+    return this.getByFilter(filter, { offset, limit }, getCount);
   }
 
   /*

--- a/server/models/Transfer.spec.js
+++ b/server/models/Transfer.spec.js
@@ -45,7 +45,6 @@ describe('Transfer Model', () => {
     transferRepositoryStub.getByFilter.resolves({result:[{id: transferId}], count: 1});
 
     const result = await transferModel.getByFilter('filter', 'limitOptions');
-    console.log('MMM', result)
     expect(result).eql({transfers :[{id: transferId}], count: 1});
     expect(transferRepositoryStub.getByFilter).calledOnceWithExactly(
       'filter',

--- a/server/models/Transfer.spec.js
+++ b/server/models/Transfer.spec.js
@@ -42,10 +42,11 @@ describe('Transfer Model', () => {
 
   it('getByFilter', async () => {
     const transferId = uuid();
-    transferRepositoryStub.getByFilter.resolves([{ id: transferId }]);
+    transferRepositoryStub.getByFilter.resolves({result:[{id: transferId}], count: 1});
 
     const result = await transferModel.getByFilter('filter', 'limitOptions');
-    expect(result).eql([{ id: transferId }]);
+    console.log('MMM', result)
+    expect(result).eql({transfers :[{id: transferId}], count: 1});
     expect(transferRepositoryStub.getByFilter).calledOnceWithExactly(
       'filter',
       'limitOptions',
@@ -57,7 +58,7 @@ describe('Transfer Model', () => {
     const walletLoginId = uuid();
     const getTransfersStub = sinon
       .stub(Transfer.prototype, 'getTransfers')
-      .resolves([{ id: transferId, walletLoginId }]);
+      .resolves({transfers: [{id: transferId, walletLoginId}]});
 
     const result = await transferModel.getById({ transferId, walletLoginId });
 
@@ -126,17 +127,18 @@ describe('Transfer Model', () => {
 
     const getByFilterStub = sinon
       .stub(Transfer.prototype, 'getByFilter')
-      .resolves([{ id: transferId }]);
+      .resolves({transfers:[{id: transferId}]});
 
     const result = await transferModel.getTransfers({
       transferId,
       walletLoginId,
       limit: 10,
+      offset: 0,
       state,
       walletId,
     });
 
-    expect(result).eql([{ id: transferId }]);
+    expect(result).eql({transfers:[{id: transferId}]});
     expect(getByFilterStub).calledOnceWithExactly(
       {
         and: [

--- a/server/repositories/TransferRepository.js
+++ b/server/repositories/TransferRepository.js
@@ -93,7 +93,7 @@ class TransferRepository extends BaseRepository {
     return transfer;
   }
 
-  async getByFilter(filter, limitOptions, getCount) {
+  async getByFilter(filter, limitOptions) {
     let promise = this._session
       .getDB()
       .select(
@@ -136,10 +136,7 @@ class TransferRepository extends BaseRepository {
     const result = await promise;
     Joi.assert(result, Joi.array().required());
 
-    if (getCount)
-      return { result, count: +count[0].count };
-
-    return result;
+    return { result, count: +count[0].count };
   }
 
   async getPendingTransfers(wallet_id) {

--- a/server/repositories/TransferRepository.spec.js
+++ b/server/repositories/TransferRepository.spec.js
@@ -67,18 +67,24 @@ describe('TransferRepository', () => {
   it('getByFilter', async () => {
     tracker.uninstall();
     tracker.install();
+
     tracker.on('query', function sendResult(query, step) {
       [
         function firstQuery() {
-          expect(query.sql).match(
-            /select.*transfer.*originating_wallet.*source_wallet.*destination_wallet/,
-          );
-          query.response([{ id: uuid.v4() }]);
+          expect(query.sql).match(/select.*count.*transfer.*originating_wallet.*source_wallet.*destination_wallet.*p/);
+          query.response([{count: '1'}]);
+        },
+        function secondQuery() {
+          expect(query.sql).match(/select.*transfer.*originating_wallet.*source_wallet.*destination_wallet/);
+          query.response([{id: uuid.v4()}])
         },
       ][step - 1]();
     });
+
     const result = await transferRepository.getByFilter({});
-    expect(result[0]).property('id').a('string');
+    expect(result).property('count').a('number')
+    expect(result).property('result').a('array')
+    expect(result.result[0]).property('id').a('string');
   });
 
   it('getPendingTransfers', async () => {

--- a/server/services/TransferService.js
+++ b/server/services/TransferService.js
@@ -13,7 +13,7 @@ class TransferService {
   }
 
   async getByFilter(query, walletLoginId) {
-    const { state, wallet, limit = 500, offset, before, after } = query;
+    const { state, wallet, limit, offset, before, after, getCount = true } = query;
 
     let walletId;
 
@@ -22,7 +22,7 @@ class TransferService {
       walletId = walletDetails.id;
     }
 
-    const results = await this._transfer.getTransfers({
+    const {transfers, count}= await this._transfer.getTransfers({
       state,
       walletId,
       offset,
@@ -30,9 +30,11 @@ class TransferService {
       walletLoginId,
       before,
       after,
+      getCount
     });
 
-    return results;
+
+    return {transfers, count};
   }
 
   async initiateTransfer(transferBody, walletLoginId) {

--- a/server/services/TransferService.js
+++ b/server/services/TransferService.js
@@ -13,7 +13,7 @@ class TransferService {
   }
 
   async getByFilter(query, walletLoginId) {
-    const { state, wallet, limit, offset, before, after, getCount = true } = query;
+    const { state, wallet, limit, offset, before, after } = query;
 
     let walletId;
 
@@ -29,8 +29,7 @@ class TransferService {
       limit,
       walletLoginId,
       before,
-      after,
-      getCount
+      after
     });
 
 

--- a/server/services/TransferService.spec.js
+++ b/server/services/TransferService.spec.js
@@ -141,7 +141,7 @@ describe('TransferService', () => {
     beforeEach(() => {
       getTransfersStub = sinon
         .stub(Transfer.prototype, 'getTransfers')
-        .resolves(['transfers']);
+        .resolves({transfers: ['transfers'], count: 1});
 
       walletGetByIdOrNameStub = sinon
         .stub(WalletService.prototype, 'getByIdOrName')
@@ -153,7 +153,8 @@ describe('TransferService', () => {
         { state: 'state', limit: 1, offset: 1 },
         'walletLoginId',
       );
-      expect(transfers).eql(['transfers']);
+      console.log('trtr', transfers)
+      expect(transfers).eql({transfers: ['transfers'], count:1});
       expect(
         getTransfersStub.calledOnceWithExactly({
           state: 'state',
@@ -182,7 +183,7 @@ describe('TransferService', () => {
         },
         'walletLoginId',
       );
-      expect(transfers).eql(['transfers']);
+      expect(transfers).eql({transfers:['transfers'], count:1});
       expect(
         getTransfersStub.calledOnceWithExactly({
           state: 'state',

--- a/server/services/TransferService.spec.js
+++ b/server/services/TransferService.spec.js
@@ -153,7 +153,6 @@ describe('TransferService', () => {
         { state: 'state', limit: 1, offset: 1 },
         'walletLoginId',
       );
-      console.log('trtr', transfers)
       expect(transfers).eql({transfers: ['transfers'], count:1});
       expect(
         getTransfersStub.calledOnceWithExactly({


### PR DESCRIPTION
## Description
The `/transfers` endpoint is updated to return pagination fields.

**Issue(s) addressed**
- Resolves #385 

**What kind of change(s) does this PR introduce?**

- [X] Enhancement
- [ ] Bug fix
- [ ] Refactor

**Please check if the PR fulfills these requirements**
- [X] The commit message follows our guidelines
- [x] Tests for the changes have been added (for bug fixes / features)
- [X] Docs have been added / updated (for bug fixes / features)

## Issue

**What is the current behavior?**
`/transfers` doesn't return `limit`, `offset`, and `total` fields.

**What is the new behavior?**
- `limit`, `offset`, and `total` are returned. 
![image](https://github.com/Greenstand/treetracker-wallet-api/assets/15161954/32d41f8a-5b70-4e0b-aca5-9d7cf11c3ef2)

-  The API spec is updated to reflect these changes.

## Breaking change

**Does this PR introduce a breaking change?**
No.

## Other useful information
None.