### PR TITLE
fix: /transfers/:id/tokens works correctly

### DIFF
--- a/server/handlers/transferHandler.spec.js
+++ b/server/handlers/transferHandler.spec.js
@@ -387,7 +387,7 @@ describe('transferRouter', () => {
     const token2Id = uuid.v4();
 
     it('transferId param should be a guid, should throw error', async () => {
-      const res = await request(app).get(`/transfers/transferId/tokens`);
+      const res = await request(app).get(`/transfers/transferId/tokens?limit=20`);
       expect(res).property('statusCode').eq(422);
       expect(res.body.message).match(/transfer_id.*guid/i);
     });
@@ -411,6 +411,7 @@ describe('transferRouter', () => {
       expect(
         getTokensByTransferIdStub.calledOnceWithExactly(
           transferId,
+          authenticatedWalletId,
           '1',
           undefined,
         ),

--- a/server/handlers/transferHandler/index.js
+++ b/server/handlers/transferHandler/index.js
@@ -115,7 +115,7 @@ const transferIdTokenGet = async (req, res) => {
 
   const transferService = new TransferService();
   const tokens = await transferService.getTokensByTransferId(
-    req.params.transfer_id,
+    req.params.transfer_id, req.wallet_id,
     limit,
     offset,
   );

--- a/server/repositories/TokenRepository.js
+++ b/server/repositories/TokenRepository.js
@@ -34,13 +34,12 @@ class TokenRepository extends BaseRepository {
    * select transaction table by transfer id, return matched tokens
    */
   async getByTransferId(transferId, limit, offset = 0) {
-    return this._session.getDB().raw(`
-      SELECT "token".* FROM "token"
-      JOIN "transaction" 
-      ON "token".id = "transaction".token_id
-      WHERE "transaction".transfer_id = ${transferId}
-      LIMIT ${limit}
-      OFFSET ${offset}`);
+    return this._session.getDB().select('*')
+        .from('token')
+        .join('transaction', 'token.id', 'transaction.token_id')
+        .where('transaction.transfer_id', transferId)
+        .limit(limit)
+        .offset(offset);
   }
 }
 

--- a/server/services/TransferService.js
+++ b/server/services/TransferService.js
@@ -219,8 +219,8 @@ class TransferService {
     return transfer;
   }
 
-  async getTokensByTransferId(transferId, limit, offset) {
-    const transfer = await this.getTransferById(transferId);
+  async getTokensByTransferId(transferId, walletLoginId, limit, offset) {
+    const transfer = await this.getTransferById(transferId, walletLoginId);
     const tokenService = new TokenService();
     let tokens;
     if (transfer.state === TransferEnums.STATE.completed) {

--- a/server/services/TransferService.spec.js
+++ b/server/services/TransferService.spec.js
@@ -106,6 +106,7 @@ describe('TransferService', () => {
 
       const tokens = await transferService.getTokensByTransferId(
         'transferId',
+        'walletLoginId',
         1,
         1,
       );
@@ -123,6 +124,7 @@ describe('TransferService', () => {
 
       const tokens = await transferService.getTokensByTransferId(
         'transferId',
+        'walletLoginId',
         1,
         1,
       );


### PR DESCRIPTION
Resolves #393.

The endpoint correctly returns the list of tokens associated with the specified transfer.