### PR TITLE
Get trust relationship by id endpoint

### DIFF
--- a/server/handlers/trustHandler.spec.js
+++ b/server/handlers/trustHandler.spec.js
@@ -210,4 +210,35 @@ describe('trustRouter', () => {
       });
     });
   });
+
+  describe('get /trust_relationships/:id', () => {
+    it('missed parameters -- relationshipId must be a guid', async () => {
+      const res = await request(app).get(
+          `/trust_relationships/trustRelationshipId`,
+      );
+      expect(res).property('statusCode').eq(422);
+      expect(res.body.message).match(/trustRelationshipId.*GUID/);
+    });
+
+    it('successfully', async () => {
+      const trustRelationshipId = uuid.v4();
+
+      const trustRelationshipGetByIdStub = sinon
+          .stub(TrustService.prototype, 'trustRelationshipGetById')
+          .resolves({id: trustRelationshipId});
+
+      const res = await request(app).get(
+          `/trust_relationships/${trustRelationshipId}`,
+      );
+
+      expect(res).property('statusCode').eq(200);
+      expect(
+          trustRelationshipGetByIdStub.calledOnceWithExactly({
+            walletLoginId: authenticatedWalletId,
+            trustRelationshipId,
+          }),
+      ).eql(true);
+    });
+
+  })
 });

--- a/server/handlers/trustHandler/index.js
+++ b/server/handlers/trustHandler/index.js
@@ -45,6 +45,23 @@ const trustPost = async (req, res) => {
   res.status(200).json(trustRelationship);
 };
 
+const trustRelationshipGetById = async (req, res) => {
+  await trustRelationshipIdSchema.validateAsync(req.params, {
+    abortEarly: false,
+  });
+
+  const { trustRelationshipId } = req.params
+  const trustService = new TrustService()
+
+  const trustRelationship = await trustService.trustRelationshipGetById({
+    walletLoginId: req.wallet_id,
+    trustRelationshipId
+  })
+
+  res.status(200).json(trustRelationship)
+}
+
+
 const trustRelationshipAccept = async (req, res) => {
   await trustRelationshipIdSchema.validateAsync(req.params, {
     abortEarly: false,
@@ -56,7 +73,7 @@ const trustRelationshipAccept = async (req, res) => {
     trustRelationshipId,
     walletLoginId: req.wallet_id,
   });
-  res.json(json);
+  res.status(200).json(json);
 };
 
 const trustRelationshipDecline = async (req, res) => {
@@ -93,4 +110,5 @@ module.exports = {
   trustRelationshipAccept,
   trustRelationshipDecline,
   trustRelationshipDelete,
+  trustRelationshipGetById
 };

--- a/server/models/Trust.js
+++ b/server/models/Trust.js
@@ -393,6 +393,31 @@ class Trust {
     return false;
   }
 
+  async getTrustRelationshipById({ walletId, trustRelationshipId}) {
+    const filter = {
+      and: [
+        {
+          or: [
+            { actor_wallet_id: walletId },
+            { target_wallet_id: walletId },
+            { originator_wallet_id: walletId },
+          ],
+        },
+        {
+          'wallet_trust.id': trustRelationshipId,
+        },
+      ],
+    };
+
+    const [trustRelationship] =  await this._trustRepository.getByFilter(filter)
+
+    if(!trustRelationship){
+      throw new HttpError(404, 'No such trust relationship exists or it is not associated with the current wallet.')
+    }
+
+    return trustRelationship
+  }
+
   // NOT YET IN USE
   //   /*
   //  * Get all the trust relationships I have requested

--- a/server/models/Trust.spec.js
+++ b/server/models/Trust.spec.js
@@ -906,4 +906,35 @@ describe('Trust Model', () => {
       expect(getTrustRelationshipsTrustedStub).not.called;
     });
   });
+
+  describe('getTrustRelationshipById', () => {
+    const walletId = uuid();
+    const trustRelationshipId = uuid()
+    const filter = {
+      and: [
+        {
+          or: [
+            { actor_wallet_id: walletId },
+            { target_wallet_id: walletId },
+            { originator_wallet_id: walletId },
+          ],
+        },
+        {
+          'wallet_trust.id': trustRelationshipId,
+        },
+      ],
+    };
+
+    it('should get relationship', async () => {
+      trustRepositoryStub.getByFilter.resolves(['trustRelationship']);
+      const result = await trustModel.getTrustRelationshipById({
+        walletId,
+        trustRelationshipId
+      });
+      expect(result).eql('trustRelationship');
+      expect(trustRepositoryStub.getByFilter).calledOnceWithExactly(
+          {...filter}
+      );
+    });
+  })
 });

--- a/server/routes/trustRouter.js
+++ b/server/routes/trustRouter.js
@@ -13,6 +13,7 @@ const {
   trustRelationshipDelete,
   trustRelationshipDecline,
   trustRelationshipAccept,
+  trustRelationshipGetById,
   trustPost,
 } = require('../handlers/trustHandler');
 
@@ -27,6 +28,7 @@ router.post(
   handlerWrapper(trustRelationshipDecline),
 );
 router.delete('/:trustRelationshipId', handlerWrapper(trustRelationshipDelete));
+router.get('/:trustRelationshipId', handlerWrapper(trustRelationshipGetById))
 
 routerWrapper.use(
   '/trust_relationships',

--- a/server/services/TrustService.js
+++ b/server/services/TrustService.js
@@ -109,6 +109,15 @@ class TrustService {
       trustRelationshipId,
     });
   }
+
+  async trustRelationshipGetById({ walletLoginId, trustRelationshipId}){
+    return this._trust.getTrustRelationshipById({
+      walletId: walletLoginId,
+      trustRelationshipId
+    })
 }
+
+}
+
 
 module.exports = TrustService;

--- a/server/services/TrustService.spec.js
+++ b/server/services/TrustService.spec.js
@@ -218,4 +218,23 @@ describe('TrustService', () => {
       ).eql(true);
     });
   });
+
+  describe('trustRelationshipGetById', async () => {
+      const trustRelationshipGetByIdStub = sinon
+          .stub(Trust.prototype, 'trustRelationshipGetById')
+          .resolves('trustRelationship');
+
+      const trustRelationship = await trustService.trustRelationshipGetById({
+          walletId: 'walletId',
+          trustRelationshipId: 'id'
+      });
+
+      expect(trustRelationship).eql('trustRelationship');
+      expect(
+          trustRelationshipGetByIdStub.calledOnceWithExactly({
+              walletId: 'walletId',
+              trustRelationshipId: 'id'
+          }),
+      ).eql(true);
+  })
 });


### PR DESCRIPTION
## Description
The endpoint `GET /trust_relationships/:id` is implemented to get details of a specific trust relationship.

**Issue(s) addressed**
Resolves #395.

**What kind of change(s) does this PR introduce?**

- [X] Enhancement
- [ ] Bug fix
- [ ] Refactor

**Please check if the PR fulfills these requirements**
- [X] The commit message follows our guidelines
- [X] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)

## Issue

**What is the current behavior?**
The endpoint `GET /trust_relationships/:id` is not implemented.

**What is the new behavior?**

- For a trust relationship id that exists and is associated with the logged in wallet, the server returns the trust relationship with `200` code:
![image](https://github.com/Greenstand/treetracker-wallet-api/assets/15161954/35bdbbb6-ae39-49e7-b835-26e44d66d4c9)

- For a non-existent id, or for a trust relationship that is not associated with the wallet, the server returns `404` error:
![image](https://github.com/Greenstand/treetracker-wallet-api/assets/15161954/cd38453e-9b62-4b2d-bdd5-479267bd9faf)

## Breaking change

**Does this PR introduce a breaking change?**
No.

## Other useful information
None.



