### PR TITLE
Created transfer returns token_count

### DIFF
--- a/server/handlers/transferHandler.spec.js
+++ b/server/handlers/transferHandler.spec.js
@@ -114,6 +114,11 @@ describe('transferRouter', () => {
         result: {
           id: tokenId,
           state: TransferEnums.STATE.completed,
+          parameters: {
+            bundle: {
+              bundleSize: 1,
+            },
+          },
         },
         status: 201,
       });
@@ -128,6 +133,12 @@ describe('transferRouter', () => {
     expect(res.body).eql({
       id: tokenId,
       state: TransferEnums.STATE.completed,
+      parameters: {
+        bundle: {
+          bundleSize: 1,
+        },
+      },
+      token_count: 1
     });
     expect(
       initiateTranferStub.calledOnceWithExactly(
@@ -151,6 +162,11 @@ describe('transferRouter', () => {
         result: {
           id: tokenId,
           state: TransferEnums.STATE.completed,
+          parameters: {
+            bundle: {
+              bundleSize: 1,
+            },
+          },
         },
         status: 202,
       });
@@ -168,6 +184,12 @@ describe('transferRouter', () => {
     expect(res.body).eql({
       id: tokenId,
       state: TransferEnums.STATE.completed,
+      parameters: {
+        bundle: {
+          bundleSize: 1,
+        },
+      },
+      token_count: 1
     });
     expect(
       initiateTranferStub.calledOnceWithExactly(

--- a/server/handlers/transferHandler/index.js
+++ b/server/handlers/transferHandler/index.js
@@ -16,7 +16,13 @@ const transferPost = async (req, res) => {
     req.wallet_id,
   );
 
-  res.status(status).send(result);
+  const modifiedTransfer = {
+    ...result,
+    token_count:
+        +result.parameters?.bundle?.bundleSize || +result.parameters?.tokens?.length,
+  }
+
+  res.status(status).send(modifiedTransfer);
 };
 
 const transferIdAcceptPost = async (req, res) => {


### PR DESCRIPTION
## Description
The `POST /transfers` endpoint returns `token_count` as a field.

**Issue(s) addressed**
- Resolves #397 

**What kind of change(s) does this PR introduce?**

- [X] Enhancement
- [ ] Bug fix
- [ ] Refactor

**Please check if the PR fulfills these requirements**
- [X] The commit message follows our guidelines
- [X] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)

## Issue

**What is the current behavior?**
The endpoint doesn't return `token_count`, unlike related endpoints `GET /transfers` and `GET /transfers/:id`.

**What is the new behavior?**
- `token_count` is returned:
![image](https://github.com/Greenstand/treetracker-wallet-api/assets/15161954/fe7bfef4-e23f-46e3-82cf-d39b5286d9dc)


## Breaking change

**Does this PR introduce a breaking change?**
No.

## Other useful information
None.