### PR TITLE
Remove unused query parameter from validation `GET /tokens/:id/transactions`

### DIFF
--- a/server/handlers/tokenHandler/schemas.js
+++ b/server/handlers/tokenHandler/schemas.js
@@ -10,7 +10,6 @@ const tokenGetTransactionsByIdSchema = Joi.object({
   limit: Joi.number().min(1).max(1000).integer().default(1000).required(),
   offset: Joi.number().min(0).integer(),
   id: Joi.string().guid(),
-  transactions: Joi.string(),
 });
 
 module.exports = {


### PR DESCRIPTION
Resolves #399.