### PR TITLE
403 Added missing fields to POST /trust_relationships

### DIFF
--- a/server/models/Trust.js
+++ b/server/models/Trust.js
@@ -124,6 +124,9 @@ class Trust {
       created_at: result.created_at,
       updated_at: result.updated_at,
       active: result.active,
+      actor_wallet_id: actorWallet.id,
+      originator_wallet_id: originatorWallet.id,
+      target_wallet_id: targetWallet.id,
     };
   }
 

--- a/server/models/Trust.spec.js
+++ b/server/models/Trust.spec.js
@@ -223,6 +223,9 @@ describe('Trust Model', () => {
         created_at: resultObject.created_at,
         updated_at: resultObject.updated_at,
         active: resultObject.active,
+        actor_wallet_id: requesterWallet.id,
+        originator_wallet_id: originatorWallet.id,
+        target_wallet_id: requesteeWallet.id,
       });
       expect(hasControlStub).calledOnceWithExactly(
         originatorWallet.id,


### PR DESCRIPTION
## Description
The `POST /trust_relationships` endpoint has been updated to return some fields it was missing, specifically `actor_wallet_id`, `originator_wallet_id`, and `target_wallet_id` fields.

**Issue(s) addressed**
- Resolves #403 

**What kind of change(s) does this PR introduce?*
- [ ] Enhancement
- [X] Bug fix
- [ ] Refactor

**Please check if the PR fulfils these requirements**

- [X] The commit message follows our guidelines
- [X] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)

## Issue

**What is the current behavior?**
The endpoint doesn't return some fields.

**What is the new behavior?**
The endpoint returns the missing fields, like so:
![image](https://github.com/Greenstand/treetracker-wallet-api/assets/15161954/de55c0a1-fd1b-46dc-9785-6690e43b393c)

## Breaking change

**Does this PR introduce a breaking change?**
No.

## Other useful information
None.