### PR TITLE
405 fix status codes for POST endpoints

### DIFF
--- a/__tests__/trust-relationship-api.spec.js
+++ b/__tests__/trust-relationship-api.spec.js
@@ -76,7 +76,7 @@ describe('Trust relationship management', () => {
         trust_request_type: 'send',
         requestee_wallet: seed.walletC.name,
       });
-    expect(res).property('statusCode').to.eq(200);
+    expect(res).property('statusCode').to.eq(201);
   });
 
   it('GET /trust_relationships', async () => {
@@ -110,7 +110,7 @@ describe('Trust relationship management', () => {
         trust_request_type: 'send',
         requestee_wallet: seed.walletB.name,
       });
-    expect(res).property('statusCode').to.eq(200);
+    expect(res).property('statusCode').to.eq(201);
   });
 
   it(`${seed.walletB.name} try to request "manage" relationship to ${seed.wallet.name}`, async () => {
@@ -124,7 +124,7 @@ describe('Trust relationship management', () => {
         trust_request_type: 'manage',
         requestee_wallet: seed.wallet.name,
       });
-    expect(res).property('statusCode').to.eq(200);
+    expect(res).property('statusCode').to.eq(201);
     const trustRelationship = res.body;
     expect(trustRelationship).property('id').to.be.a.uuid('v4');
     expect(trustRelationship)
@@ -158,7 +158,7 @@ describe('Trust relationship management', () => {
         trust_request_type: 'yield',
         requestee_wallet: seed.wallet.name,
       });
-    expect(res).property('statusCode').to.eq(200);
+    expect(res).property('statusCode').to.eq(201);
     const trustRelationship = res.body;
     expect(trustRelationship).property('id').to.be.a.uuid('v4');
     expect(trustRelationship)
@@ -167,7 +167,7 @@ describe('Trust relationship management', () => {
     trustRelationshipId = trustRelationship.id;
   });
 
-  it(`${seed.wallet.name} accept yeild request`, async () => {
+  it(`${seed.wallet.name} accept yield request`, async () => {
     const res = await request(server)
       .post(`/trust_relationships/${trustRelationshipId}/accept`)
       .set('Content-Type', 'application/json')

--- a/__tests__/trust-relationship-send-cancel.spec.js
+++ b/__tests__/trust-relationship-send-cancel.spec.js
@@ -55,7 +55,7 @@ describe('Trust relationship: cancel send', () => {
         trust_request_type: 'send',
         requestee_wallet: seed.walletB.name,
       });
-    expect(res).property('statusCode').to.eq(200);
+    expect(res).property('statusCode').to.eq(201);
     trustRelationship = res.body;
   });
 

--- a/__tests__/trust-relationship-send-decline.spec.js
+++ b/__tests__/trust-relationship-send-decline.spec.js
@@ -62,7 +62,7 @@ describe('Trust relationship: decline send', () => {
         trust_request_type: 'send',
         requestee_wallet: seed.walletB.name,
       });
-    expect(res).property('statusCode').to.eq(200);
+    expect(res).property('statusCode').to.eq(201);
     trustRelationship = res.body;
     expect(trustRelationship).property('id').to.be.a.uuid('v4');
     expect(trustRelationship)

--- a/__tests__/trust-relationship-send.spec.js
+++ b/__tests__/trust-relationship-send.spec.js
@@ -82,7 +82,7 @@ describe('Trust relationship: send', () => {
         trust_request_type: 'send',
         requestee_wallet: seed.walletB.name,
       });
-    expect(res).property('statusCode').to.eq(200);
+    expect(res).property('statusCode').to.eq(201);
     trustRelationship = res.body;
     expect(trustRelationship).property('id').to.be.a.uuid('v4');
     expect(trustRelationship)

--- a/server/handlers/trustHandler.spec.js
+++ b/server/handlers/trustHandler.spec.js
@@ -70,7 +70,7 @@ describe('trustRouter', () => {
         requestee_wallet: walletId,
       });
 
-      expect(res).property('statusCode').eq(200);
+      expect(res).property('statusCode').eq(201);
       expect(
         createTrustRelationshipStub.calledOnceWithExactly({
           walletLoginId: authenticatedWalletId,

--- a/server/handlers/trustHandler/index.js
+++ b/server/handlers/trustHandler/index.js
@@ -42,7 +42,7 @@ const trustPost = async (req, res) => {
     trustRequestType: req.body.trust_request_type,
   });
 
-  res.status(200).json(trustRelationship);
+  res.status(201).json(trustRelationship);
 };
 
 const trustRelationshipGetById = async (req, res) => {

--- a/server/handlers/walletHandler.spec.js
+++ b/server/handlers/walletHandler.spec.js
@@ -153,7 +153,7 @@ describe('walletRouter', () => {
       const res = await request(app).post('/wallets').send({
         wallet: mockWallet.wallet,
       });
-      expect(res).property('statusCode').eq(200);
+      expect(res).property('statusCode').eq(201);
       expect(res.body.wallet).eq(mockWallet.wallet);
       expect(res.body.id).eq(mockWallet.id);
       expect(

--- a/server/handlers/walletHandler/index.js
+++ b/server/handlers/walletHandler/index.js
@@ -63,7 +63,7 @@ const walletPost = async (req, res) => {
     req.body.wallet,
   );
 
-  res.status(200).json({
+  res.status(201).json({
     id,
     wallet,
   });


### PR DESCRIPTION
## Description
The endpoints ` POST /wallets` and `POST /trust_relationships` should return 201 Created status code.

**Issue(s) addressed**
- Resolves #405 

**What kind of change(s) does this PR introduce?**
- [ ] Enhancement
- [X] Bug fix
- [ ] Refactor

**Please check if the PR fulfils these requirements**
- [X] The commit message follows our guidelines
- [X] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)

## Issue

**What is the current behavior?**
The endpoints return 200 OK code on successful execution.

**What is the new behavior?**
The endpoints return 201 Created on successful execution.

## Breaking change

**Does this PR introduce a breaking change?**
No.

## Other useful information
None.