### PR TITLE
407 Add 404 errors for some endpoints

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
 as
 #API Documentation
 
-To view the specs for the new API visit https://editor.swagger.io and load the YAML file from /docs/api/spec/treetracker-token-api.yaml
+To view the specs for the new API visit https://editor.swagger.io and load the YAML file from https://github.com/Greenstand/treetracker-wallet-api/docs/api/spec/treetracker-wallet-api-v1-10.yaml
 
 # Getting Started
 

--- a/server/models/Trust.js
+++ b/server/models/Trust.js
@@ -336,6 +336,14 @@ class Trust {
       'wallet_trust.id': trustRelationshipId,
     });
     const [trustRelationship] = trustRelationships;
+
+    if(!trustRelationship){
+      throw new HttpError(
+          404,
+          'No such trust relationship exists or it is not associated with the current wallet.'
+      )
+    }
+
     if (trustRelationship?.originator_wallet_id !== walletId) {
       throw new HttpError(
         403,

--- a/server/models/Trust.js
+++ b/server/models/Trust.js
@@ -335,7 +335,24 @@ class Trust {
    * Cancel a trust relationship request
    */
   async cancelTrustRequest({ trustRelationshipId, walletId }) {
-    const trustRelationship = await this.getTrustRelationshipById({ walletId, trustRelationshipId})
+    const trustRelationships = await this._trustRepository.getByFilter({
+      'wallet_trust.id': trustRelationshipId,
+    });
+    const [trustRelationship] = trustRelationships;
+
+    if(!trustRelationship){
+      throw new HttpError(
+          404,
+          'No such trust relationship exists or it is not associated with the current wallet.'
+      )
+    }
+
+    if (trustRelationship?.originator_wallet_id !== walletId) {
+      throw new HttpError(
+        403,
+        'Have no permission to cancel this relationship',
+      );
+    }
 
     return this.updateTrustState(
       trustRelationship,

--- a/server/models/Trust.js
+++ b/server/models/Trust.js
@@ -289,8 +289,8 @@ class Trust {
 
     if (!trustRelationship) {
       throw new HttpError(
-        403,
-        'Have no permission to accept this relationship',
+        404,
+        'No such trust relationship exists or it is not associated with the current wallet.',
       );
     }
     await this.checkManageCircle({ walletId, trustRelationship });
@@ -317,8 +317,8 @@ class Trust {
 
     if (!trustRelationship) {
       throw new HttpError(
-        403,
-        'Have no permission to decline this relationship',
+        404,
+        'No such trust relationship exists or it is not associated with the current wallet.',
       );
     }
 
@@ -332,24 +332,7 @@ class Trust {
    * Cancel a trust relationship request
    */
   async cancelTrustRequest({ trustRelationshipId, walletId }) {
-    const trustRelationships = await this._trustRepository.getByFilter({
-      'wallet_trust.id': trustRelationshipId,
-    });
-    const [trustRelationship] = trustRelationships;
-
-    if(!trustRelationship){
-      throw new HttpError(
-          404,
-          'No such trust relationship exists or it is not associated with the current wallet.'
-      )
-    }
-
-    if (trustRelationship?.originator_wallet_id !== walletId) {
-      throw new HttpError(
-        403,
-        'Have no permission to cancel this relationship',
-      );
-    }
+    const trustRelationship = await this.getTrustRelationshipById({ walletId, trustRelationshipId})
 
     return this.updateTrustState(
       trustRelationship,

--- a/server/models/Trust.spec.js
+++ b/server/models/Trust.spec.js
@@ -744,21 +744,6 @@ describe('Trust Model', () => {
       const trustRelationshipId = uuid();
       const walletId = uuid();
 
-      const filter = {
-        and: [
-          {
-            or: [
-              { actor_wallet_id: walletId },
-              { target_wallet_id: walletId },
-              { originator_wallet_id: walletId },
-            ],
-          },
-          {
-            'wallet_trust.id': trustRelationshipId,
-          },
-        ],
-      };
-
       let error;
       try {
         await trustModel.cancelTrustRequest({
@@ -773,28 +758,15 @@ describe('Trust Model', () => {
       expect(error.message).eql(
         'No such trust relationship exists or it is not associated with the current wallet.',
       );
-      expect(trustRepositoryStub.getByFilter).calledOnceWithExactly(filter);
+      expect(trustRepositoryStub.getByFilter).calledOnceWithExactly({
+        'wallet_trust.id': trustRelationshipId,
+      });
       expect(updateTrustStateStub).not.called;
     });
 
     it('should cancel', async () => {
       const trustRelationshipId = uuid();
       const walletId = uuid();
-
-      const filter = {
-        and: [
-          {
-            or: [
-              { actor_wallet_id: walletId },
-              { target_wallet_id: walletId },
-              { originator_wallet_id: walletId },
-            ],
-          },
-          {
-            'wallet_trust.id': trustRelationshipId,
-          },
-        ],
-      };
 
       trustRepositoryStub.getByFilter.resolves([
         { originator_wallet_id: walletId, id: trustRelationshipId },
@@ -807,7 +779,9 @@ describe('Trust Model', () => {
 
       expect(result).eql('state cancelled');
 
-      expect(trustRepositoryStub.getByFilter).calledOnceWithExactly(filter);
+      expect(trustRepositoryStub.getByFilter).calledOnceWithExactly({
+        'wallet_trust.id': trustRelationshipId,
+      });
       expect(updateTrustStateStub).calledOnceWithExactly(
         { originator_wallet_id: walletId, id: trustRelationshipId },
         TrustRelationshipEnums.ENTITY_TRUST_STATE_TYPE.cancelled_by_originator,

--- a/server/services/TrustService.js
+++ b/server/services/TrustService.js
@@ -109,11 +109,6 @@ class TrustService {
   }
 
   async cancelTrustRequest({ walletLoginId, trustRelationshipId }) {
-    // check if trust relationship matching trustRelationshipId exists
-    // const trs = await this._session.getDB().select('*').from('wallet_trust').where('id', trustRelationshipId)
-    // console.log('TRUSTS', trs)
-
-
     return this._trust.cancelTrustRequest({
       walletId: walletLoginId,
       trustRelationshipId,

--- a/server/services/TrustService.js
+++ b/server/services/TrustService.js
@@ -17,7 +17,7 @@ class TrustService {
     offset = 0,
     limit,
   }) {
-    // check of wallet exists first
+    // check if wallet exists first
     // throws error if no wallet matching walletId exists
     const walletService = new WalletService()
     await walletService.getWallet(walletId)

--- a/server/services/TrustService.js
+++ b/server/services/TrustService.js
@@ -17,6 +17,11 @@ class TrustService {
     offset = 0,
     limit,
   }) {
+    // check of wallet exists first
+    // throws error if no wallet matching walletId exists
+    const walletService = new WalletService()
+    await walletService.getWallet(walletId)
+
     return this._trust.getTrustRelationships({
       walletId,
       state,
@@ -104,6 +109,11 @@ class TrustService {
   }
 
   async cancelTrustRequest({ walletLoginId, trustRelationshipId }) {
+    // check if trust relationship matching trustRelationshipId exists
+    // const trs = await this._session.getDB().select('*').from('wallet_trust').where('id', trustRelationshipId)
+    // console.log('TRUSTS', trs)
+
+
     return this._trust.cancelTrustRequest({
       walletId: walletLoginId,
       trustRelationshipId,

--- a/server/services/TrustService.spec.js
+++ b/server/services/TrustService.spec.js
@@ -23,6 +23,10 @@ describe('TrustService', () => {
       .stub(Trust.prototype, 'getTrustRelationships')
       .resolves(['trustRelationships']);
 
+    const getWalletStub = sinon
+        .stub(WalletService.prototype, 'getWallet')
+        .resolves({id: 'walletId'})
+
     const trustRelationship = await trustService.getTrustRelationships({
       walletId: 'walletId',
       state: 'state',
@@ -32,6 +36,9 @@ describe('TrustService', () => {
     });
 
     expect(trustRelationship).eql(['trustRelationships']);
+    expect(getWalletStub.calledOnceWithExactly({
+        walletId: 'walletId',
+    }))
     expect(
       getTrustRelationshipsStub.calledOnceWithExactly({
         walletId: 'walletId',


### PR DESCRIPTION
## Description
The endpoints mentioned in the issue below now show appropriate error codes.

**Issue(s) addressed**
- Resolves #407 

**What kind of change(s) does this PR introduce?**
- [ ] Enhancement
- [X] Bug fix
- [ ] Refactor

**Please check if the PR fulfils these requirements**
- [X] The commit message follows our guidelines
- [X] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)

## Issue

**What is the current behavior?**
403 code is being used where 404 should be used.

**What is the new behavior?**
The endpoints return 404 is the entity matching the query parameter is not found or is associated with a different wallet. 

## Breaking change

**Does this PR introduce a breaking change?**
No.

## Other useful information
None.