### PR TITLE
fix: transfer request claim is optional parameter

### DIFF
--- a/server/handlers/transferHandler.spec.js
+++ b/server/handlers/transferHandler.spec.js
@@ -146,6 +146,7 @@ describe('transferRouter', () => {
           tokens: ['1'],
           sender_wallet: 'wallet1',
           receiver_wallet: 'wallet2',
+          claim: false,
         },
         authenticatedWalletId,
       ),

--- a/server/handlers/transferHandler/index.js
+++ b/server/handlers/transferHandler/index.js
@@ -8,11 +8,11 @@ const {
 } = require('./schemas');
 
 const transferPost = async (req, res) => {
-  await transferPostSchema.validateAsync(req.body, { abortEarly: false });
+  const validatedData = await transferPostSchema.validateAsync(req.body, { abortEarly: false });
   const transferService = new TransferService();
 
   const { result, status } = await transferService.initiateTransfer(
-    req.body,
+    validatedData,
     req.wallet_id,
   );
 

--- a/server/handlers/transferHandler/schemas.js
+++ b/server/handlers/transferHandler/schemas.js
@@ -12,8 +12,7 @@ const transferPostSchema = Joi.alternatives()
         tokens: Joi.array().items(Joi.string()).required().unique(),
         sender_wallet: Joi.alternatives().try(Joi.string()).required(),
         receiver_wallet: Joi.alternatives().try(Joi.string()).required(),
-        // TODO: add boolean for claim, but default to false.
-        claim: Joi.boolean(),
+        claim: Joi.boolean().default(false),
       }),
       otherwise: Joi.object({
         bundle: Joi.object({
@@ -21,7 +20,7 @@ const transferPostSchema = Joi.alternatives()
         }).required(),
         sender_wallet: Joi.string().required(),
         receiver_wallet: Joi.string().required(),
-        claim: Joi.boolean().required(),
+        claim: Joi.boolean().default(false),
       }),
     },
   );


### PR DESCRIPTION
## Description
The endpoint `POST /transfers` takes in `claim` as optional parameter. The functionality behind claiming a token is not yet implemented however. 

**Issue(s) addressed**
- Resolves #409 

**What kind of change(s) does this PR introduce?**
- [ ] Enhancement
- [X] Bug fix
- [ ] Refactor

**Please check if the PR fulfils these requirements**
- [X] The commit message follows our guidelines
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)

## Issue

**What is the current behavior?**
The transfer request schema validation checks for the claim parameter, which it shouldn't do.

**What is the new behavior?**
Claim is optional, with a default value of `false`

## Breaking change

**Does this PR introduce a breaking change?**
No.

## Other useful information
None.