### PR TITLE
`before` query parameter returns results that also fall on same date 

### DIFF
--- a/server/repositories/BaseRepository.js
+++ b/server/repositories/BaseRepository.js
@@ -51,11 +51,7 @@ class BaseRepository {
       const filterObjectCopy = { ...object };
       const beforeFilter = object.before;
       if (object.before) {
-        result.where(
-          Object.keys(beforeFilter)[0],
-          '<=',
-          Object.values(beforeFilter)[0],
-        );
+        result.whereRaw(`cast(${Object.keys(beforeFilter)[0]} as date) <= ?`, [Object.values(beforeFilter)[0]])
         delete filterObjectCopy.before;
       }
       const afterFilter = object.after;


### PR DESCRIPTION
## Description
For `GET /transfers` (and potential future endpoints using the same), `before` query parameter returns results that  also fall on the same date.

**Issue(s) addressed**
- Resolves #401 

**What kind of change(s) does this PR introduce?**
- [ ] Enhancement
- [X] Bug fix
- [ ] Refactor

**Please check if the PR fulfils these requirements**
- [X] The commit message follows our guidelines
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)

## Issue

**What is the current behavior?**
The endpoint does not include transfers that were created on the same date as `before`, which is erroneous.

**What is the new behavior?**
The endpoint correctly returns the result.

## Breaking change

**Does this PR introduce a breaking change?**
No.

## Other useful information
None.