### PR TITLE
#391: Addition of sort_by Query Parameter

### DIFF
--- a/server/handlers/transferHandler/schemas.js
+++ b/server/handlers/transferHandler/schemas.js
@@ -61,7 +61,8 @@ const transferGetQuerySchema = Joi.object({
   after: Joi.date().iso(),
   limit: Joi.number().min(1).max(1000),
   offset: Joi.number().min(0).integer().default(0),
-  sort_by: Joi.string().pattern(new RegExp(`^(-)?(${Object.values(TransferEnums.SORT).join('|')})$`)).optional(),
+  sort_by: Joi.string().valid(...Object.values(TransferEnums.SORT)).optional(),
+  order: Joi.string().valid('desc', 'asc').optional(),
 });
 
 module.exports = {

--- a/server/handlers/transferHandler/schemas.js
+++ b/server/handlers/transferHandler/schemas.js
@@ -61,6 +61,7 @@ const transferGetQuerySchema = Joi.object({
   after: Joi.date().iso(),
   limit: Joi.number().min(1).max(1000),
   offset: Joi.number().min(0).integer().default(0),
+  sort_by: Joi.string().pattern(new RegExp(`^(-)?(${Object.values(TransferEnums.SORT).join('|')})$`)).optional(),
 });
 
 module.exports = {

--- a/server/models/Transfer.js
+++ b/server/models/Transfer.js
@@ -65,6 +65,7 @@ class Transfer {
     transferId,
     before,
     after,
+    sort_by,
   }) {
     const filter = {
       and: [],
@@ -97,7 +98,7 @@ class Transfer {
     if (after) {
       filter.and.push({ after: { 'transfer.created_at': after } });
     }
-    return this.getByFilter(filter, { offset, limit });
+    return this.getByFilter(filter, { offset, limit, sort_by });
   }
 
   /*

--- a/server/models/Transfer.js
+++ b/server/models/Transfer.js
@@ -66,6 +66,7 @@ class Transfer {
     before,
     after,
     sort_by,
+    order,
   }) {
     const filter = {
       and: [],
@@ -98,7 +99,7 @@ class Transfer {
     if (after) {
       filter.and.push({ after: { 'transfer.created_at': after } });
     }
-    return this.getByFilter(filter, { offset, limit, sort_by });
+    return this.getByFilter(filter, { offset, limit, sort_by, order });
   }
 
   /*

--- a/server/models/Transfer.spec.js
+++ b/server/models/Transfer.spec.js
@@ -136,6 +136,7 @@ describe('Transfer Model', () => {
       state,
       walletId,
       sort_by: null,
+      order: null,
     });
 
     expect(result).eql({transfers:[{id: transferId}]});
@@ -160,7 +161,7 @@ describe('Transfer Model', () => {
           { 'transfer.id': transferId },
         ],
       },
-      { limit: 10, offset: 0, sort_by: null },
+      { limit: 10, offset: 0, sort_by: null, order: null },
     );
   });
 

--- a/server/models/Transfer.spec.js
+++ b/server/models/Transfer.spec.js
@@ -135,6 +135,7 @@ describe('Transfer Model', () => {
       offset: 0,
       state,
       walletId,
+      sort_by: null,
     });
 
     expect(result).eql({transfers:[{id: transferId}]});
@@ -159,7 +160,7 @@ describe('Transfer Model', () => {
           { 'transfer.id': transferId },
         ],
       },
-      { limit: 10, offset: 0 },
+      { limit: 10, offset: 0, sort_by: null },
     );
   });
 

--- a/server/repositories/TransferRepository.js
+++ b/server/repositories/TransferRepository.js
@@ -123,6 +123,16 @@ class TransferRepository extends BaseRepository {
       )
       .where((builder) => this.whereBuilder(filter, builder));
 
+    if (limitOptions && limitOptions.sort_by) {
+      const column = limitOptions.sort_by.startsWith('-') ? 
+        limitOptions.sort_by.slice(1) : limitOptions.sort_by;
+      const order = limitOptions.sort_by.startsWith('-') ? 'desc' : 'asc';
+      promise = promise.orderBy(column, order);
+    } else {
+      // sort by created time by default
+      promise = promise.orderBy('transfer.created_at', 'desc');
+    }
+
     // get the total count (before applying limit and offset options)
     const count = await this._session.getDB().from(promise.as('p')).count('*');
 

--- a/server/repositories/TransferRepository.js
+++ b/server/repositories/TransferRepository.js
@@ -122,16 +122,19 @@ class TransferRepository extends BaseRepository {
         'destination_wallet.id',
       )
       .where((builder) => this.whereBuilder(filter, builder));
+    
+    let order = 'desc';
+    let column = 'transfer.created_at';
 
-    if (limitOptions && limitOptions.sort_by) {
-      const column = limitOptions.sort_by.startsWith('-') ? 
-        limitOptions.sort_by.slice(1) : limitOptions.sort_by;
-      const order = limitOptions.sort_by.startsWith('-') ? 'desc' : 'asc';
-      promise = promise.orderBy(column, order);
-    } else {
-      // sort by created time by default
-      promise = promise.orderBy('transfer.created_at', 'desc');
+    if (limitOptions) {
+      if (limitOptions.order) {
+        order = limitOptions.order;
+      }
+      if (limitOptions.sort_by) {
+        column = limitOptions.sort_by;
+      }
     }
+    promise = promise.orderBy(column, order);
 
     // get the total count (before applying limit and offset options)
     const count = await this._session.getDB().from(promise.as('p')).count('*');

--- a/server/services/TransferService.js
+++ b/server/services/TransferService.js
@@ -13,7 +13,7 @@ class TransferService {
   }
 
   async getByFilter(query, walletLoginId) {
-    const { state, wallet, limit, offset, before, after } = query;
+    const { state, wallet, limit, offset, before, after, sort_by } = query;
 
     let walletId;
 
@@ -29,7 +29,8 @@ class TransferService {
       limit,
       walletLoginId,
       before,
-      after
+      after,
+      sort_by
     });
 
 

--- a/server/services/TransferService.js
+++ b/server/services/TransferService.js
@@ -13,7 +13,7 @@ class TransferService {
   }
 
   async getByFilter(query, walletLoginId) {
-    const { state, wallet, limit, offset, before, after, sort_by } = query;
+    const { state, wallet, limit, offset, before, after, sort_by, order } = query;
 
     let walletId;
 
@@ -30,7 +30,8 @@ class TransferService {
       walletLoginId,
       before,
       after,
-      sort_by
+      sort_by,
+      order
     });
 
 

--- a/server/services/TransferService.spec.js
+++ b/server/services/TransferService.spec.js
@@ -165,6 +165,7 @@ describe('TransferService', () => {
           walletId: undefined,
           before: undefined,
           after: undefined,
+          sort_by: undefined,
         }),
       ).eql(true);
       expect(walletGetByIdOrNameStub.notCalled).eql(true);
@@ -194,6 +195,7 @@ describe('TransferService', () => {
           walletId: 'id',
           before,
           after,
+          sort_by: undefined,
         }),
       ).eql(true);
       expect(walletGetByIdOrNameStub.calledOnceWithExactly('wallet')).eql(true);

--- a/server/services/TransferService.spec.js
+++ b/server/services/TransferService.spec.js
@@ -166,6 +166,7 @@ describe('TransferService', () => {
           before: undefined,
           after: undefined,
           sort_by: undefined,
+          order: undefined,
         }),
       ).eql(true);
       expect(walletGetByIdOrNameStub.notCalled).eql(true);
@@ -196,6 +197,7 @@ describe('TransferService', () => {
           before,
           after,
           sort_by: undefined,
+          order: undefined,
         }),
       ).eql(true);
       expect(walletGetByIdOrNameStub.calledOnceWithExactly('wallet')).eql(true);

--- a/server/utils/transfer-enum.js
+++ b/server/utils/transfer-enum.js
@@ -14,4 +14,14 @@ TransferEnums.STATE = {
   failed: 'failed',
 };
 
+TransferEnums.SORT = {
+  id: 'id',
+  source_wallet_id: 'source_wallet_id',
+  destination_wallet_id: 'destination_wallet_id',
+  originator_wallet_id: 'originator_wallet_id',
+  created_at: 'created_at',
+  close_at: 'closed_at',
+  state: 'state',
+};
+
 module.exports = TransferEnums;


### PR DESCRIPTION
Added the `sort_by` parameter which allows clients to specify the column by which they wish to sort the transfer results.

Usage:
1. **Column Specification**: The possible values for this parameter are defined in `TransferEnums.SORT`
2. **Direction Specification**: To sort in descending order for the specified column, simply prefix the value with a `-`.
**Example**:
- Sort by `created_at` in ascending order: `.../transfers?...&sort_by=created_at`
- Sort by `created_at` in descending order: `.../transfers?...&sort_by=-created_at`
3. If no `sort_by` is provided, the results would be sorted by _created_at_ in descending order.