### PR TITLE
fix: get /wallets returns correct pagination

### DIFF
--- a/__tests__/wallet-get.spec.js
+++ b/__tests__/wallet-get.spec.js
@@ -116,6 +116,7 @@ describe('Wallet: Get wallets of an account', () => {
 
         expect(res).property('statusCode').to.eq(200);
         expect(res.body.total).to.eq(11);
+        expect(res.body.query.offset).to.eq('0');
 
         const resB = await request(server)
             .get('/wallets')
@@ -125,7 +126,8 @@ describe('Wallet: Get wallets of an account', () => {
             .set('Authorization', `Bearer ${bearerTokenA}`);
 
         expect(resB).property('statusCode').to.eq(200);
-        expect(resB.body.total).to.eq(9);
+        expect(resB.body.total).to.eq(11);
+        expect(resB.body.query.offset).to.eq('2');
 
         const resC = await request(server)
             .get('/wallets')
@@ -134,7 +136,9 @@ describe('Wallet: Get wallets of an account', () => {
             .set('content-type', 'application/json')
             .set('Authorization', `Bearer ${bearerTokenA}`);
         expect(resC).property('statusCode').to.eq(200);
-        expect(resC.body.total).to.eq(2);
+        expect(resC.body.total).to.eq(11);
+        expect(resC.body.query.offset).to.eq('0');
+        expect(resC.body.query.limit).to.eq('2');
     })
 
     it('Get wallet by valid uuid', async () => {

--- a/__tests__/wallet-get.spec.js
+++ b/__tests__/wallet-get.spec.js
@@ -1,6 +1,6 @@
 require('dotenv').config();
 const request = require('supertest');
-const {expect} = require('chai');
+const { expect } = require('chai');
 const sinon = require('sinon');
 const chai = require('chai');
 const server = require('../server/app');
@@ -8,156 +8,156 @@ const seed = require('./seed');
 chai.use(require('chai-uuid'));
 const WalletService = require('../server/services/WalletService');
 
-const {apiKey} = seed;
+const { apiKey } = seed;
 
 describe('Wallet: Get wallets of an account', () => {
-    let bearerTokenA;
-    let bearerTokenB;
+  let bearerTokenA;
+  let bearerTokenB;
 
-    before(async () => {
-        await seed.clear();
-        await seed.seed();
+  before(async () => {
+    await seed.clear();
+    await seed.seed();
 
-        {
-            // Authorizes before each of the follow tests
-            const res = await request(server)
-                .post('/auth')
-                .set('treetracker-api-key', apiKey)
-                .send({
-                    wallet: seed.wallet.name,
-                    password: seed.wallet.password,
-                });
+    {
+      // Authorizes before each of the follow tests
+      const res = await request(server)
+        .post('/auth')
+        .set('treetracker-api-key', apiKey)
+        .send({
+          wallet: seed.wallet.name,
+          password: seed.wallet.password,
+        });
 
-            expect(res).to.have.property('statusCode', 200);
-            bearerTokenA = res.body.token;
-            expect(bearerTokenA).to.match(/\S+/);
-        }
+      expect(res).to.have.property('statusCode', 200);
+      bearerTokenA = res.body.token;
+      expect(bearerTokenA).to.match(/\S+/);
+    }
 
-        {
-            // Authorizes before each of the follow tests
-            const res = await request(server)
-                .post('/auth')
-                .set('treetracker-api-key', apiKey)
-                .send({
-                    wallet: seed.walletB.name,
-                    password: seed.walletB.password,
-                });
-            expect(res).to.have.property('statusCode', 200);
-            bearerTokenB = res.body.token;
-            expect(bearerTokenB).to.match(/\S+/);
-        }
+    {
+      // Authorizes before each of the follow tests
+      const res = await request(server)
+        .post('/auth')
+        .set('treetracker-api-key', apiKey)
+        .send({
+          wallet: seed.walletB.name,
+          password: seed.walletB.password,
+        });
+      expect(res).to.have.property('statusCode', 200);
+      bearerTokenB = res.body.token;
+      expect(bearerTokenB).to.match(/\S+/);
+    }
 
-        const walletService = new WalletService();
+    const walletService = new WalletService();
 
-        for (let i = 0; i < 10; i += 1) {
-            await walletService.createWallet(seed.wallet.id, `test${i}`)
-        }
+    for (let i = 0; i < 10; i += 1) {
+      await walletService.createWallet(seed.wallet.id, `test${i}`);
+    }
 
-        const res = await walletService.getAllWallets(seed.wallet.id);
-        expect(res.count).to.eq(11);
-    });
+    const res = await walletService.getAllWallets(seed.wallet.id);
+    expect(res.count).to.eq(11);
+  });
 
-    beforeEach(async () => {
-        sinon.restore();
-    });
+  beforeEach(async () => {
+    sinon.restore();
+  });
 
-    it('Get wallets of WalletA without params', async () => {
-        const res = await request(server)
-            .get('/wallets')
-            .set('treetracker-api-key', apiKey)
-            .set('content-type', 'application/json')
-            .set('Authorization', `Bearer ${bearerTokenA}`);
+  it('Get wallets of WalletA without params', async () => {
+    const res = await request(server)
+      .get('/wallets')
+      .set('treetracker-api-key', apiKey)
+      .set('content-type', 'application/json')
+      .set('Authorization', `Bearer ${bearerTokenA}`);
 
-        expect(res).property('statusCode').to.eq(200);
-        expect(res.body.total).to.eq(11);
+    expect(res).property('statusCode').to.eq(200);
+    expect(res.body.total).to.eq(11);
 
-        const resB = await request(server)
-            .get('/wallets')
-            .set('treetracker-api-key', apiKey)
-            .set('content-type', 'application/json')
-            .set('Authorization', `Bearer ${bearerTokenB}`);
+    const resB = await request(server)
+      .get('/wallets')
+      .set('treetracker-api-key', apiKey)
+      .set('content-type', 'application/json')
+      .set('Authorization', `Bearer ${bearerTokenB}`);
 
-        expect(resB).property('statusCode').to.eq(200);
-        expect(resB.body.total).to.eq(2);
-    });
+    expect(resB).property('statusCode').to.eq(200);
+    expect(resB.body.total).to.eq(2);
+  });
 
-    it('Get wallet by wallet name, success', async () => {
-        const res = await request(server)
-            .get('/wallets')
-            .query({name: 'walletB'})
-            .set('treetracker-api-key', apiKey)
-            .set('content-type', 'application/json')
-            .set('Authorization', `Bearer ${bearerTokenB}`);
+  it('Get wallet by wallet name, success', async () => {
+    const res = await request(server)
+      .get('/wallets')
+      .query({ name: 'walletB' })
+      .set('treetracker-api-key', apiKey)
+      .set('content-type', 'application/json')
+      .set('Authorization', `Bearer ${bearerTokenB}`);
 
-        expect(res).property('statusCode').to.eq(200);
-        expect(res.body.total).to.eq(1);
-    })
+    expect(res).property('statusCode').to.eq(200);
+    expect(res.body.total).to.eq(1);
+  });
 
-    it('Get wallet which is managed by other account', async () => {
-        const res = await request(server)
-            .get(`/wallets`)
-            .query({name: 'test0'})
-            .set('treetracker-api-key', apiKey)
-            .set('content-type', 'application/json')
-            .set('Authorization', `Bearer ${bearerTokenB}`);
+  it('Get wallet which is managed by other account', async () => {
+    const res = await request(server)
+      .get(`/wallets`)
+      .query({ name: 'test0' })
+      .set('treetracker-api-key', apiKey)
+      .set('content-type', 'application/json')
+      .set('Authorization', `Bearer ${bearerTokenB}`);
 
-        expect(res).property('statusCode').to.eq(200);
-        expect(res.body.total).to.eq(1);
-        expect(res.body.wallets[0].name).to.eq(seed.walletB.name);
-    })
+    expect(res).property('statusCode').to.eq(200);
+    expect(res.body.total).to.eq(1);
+    expect(res.body.wallets[0].name).to.eq(seed.walletB.name);
+  });
 
-    it('Get wallet with offset val', async () => {
-        const res = await request(server)
-            .get('/wallets')
-            .query({offset: 0})
-            .set('treetracker-api-key', apiKey)
-            .set('content-type', 'application/json')
-            .set('Authorization', `Bearer ${bearerTokenA}`);
+  it('Get wallet with offset val', async () => {
+    const res = await request(server)
+      .get('/wallets')
+      .query({ offset: 0 })
+      .set('treetracker-api-key', apiKey)
+      .set('content-type', 'application/json')
+      .set('Authorization', `Bearer ${bearerTokenA}`);
 
-        expect(res).property('statusCode').to.eq(200);
-        expect(res.body.total).to.eq(11);
-        expect(res.body.query.offset).to.eq(0);
+    expect(res).property('statusCode').to.eq(200);
+    expect(res.body.total).to.eq(11);
+    expect(+res.body.query.offset).to.eq(0);
 
-        const resB = await request(server)
-            .get('/wallets')
-            .query({limit: 100, offset: 2})
-            .set('treetracker-api-key', apiKey)
-            .set('content-type', 'application/json')
-            .set('Authorization', `Bearer ${bearerTokenA}`);
+    const resB = await request(server)
+      .get('/wallets')
+      .query({ limit: 100, offset: 2 })
+      .set('treetracker-api-key', apiKey)
+      .set('content-type', 'application/json')
+      .set('Authorization', `Bearer ${bearerTokenA}`);
 
-        expect(resB).property('statusCode').to.eq(200);
-        expect(resB.body.total).to.eq(11);
-        expect(resB.body.query.offset).to.eq(2);
+    expect(resB).property('statusCode').to.eq(200);
+    expect(resB.body.total).to.eq(11);
+    expect(+resB.body.query.offset).to.eq(2);
 
-        const resC = await request(server)
-            .get('/wallets')
-            .query({limit: 2, offset: 0})
-            .set('treetracker-api-key', apiKey)
-            .set('content-type', 'application/json')
-            .set('Authorization', `Bearer ${bearerTokenA}`);
-        expect(resC).property('statusCode').to.eq(200);
-        expect(resC.body.total).to.eq(11);
-        expect(resC.body.query.offset).to.eq(0);
-        expect(resC.body.query.limit).to.eq(2);
-    })
+    const resC = await request(server)
+      .get('/wallets')
+      .query({ limit: 2, offset: 0 })
+      .set('treetracker-api-key', apiKey)
+      .set('content-type', 'application/json')
+      .set('Authorization', `Bearer ${bearerTokenA}`);
+    expect(resC).property('statusCode').to.eq(200);
+    expect(resC.body.total).to.eq(11);
+    expect(+resC.body.query.offset).to.eq(0);
+    expect(+resC.body.query.limit).to.eq(2);
+  });
 
-    it('Get wallet by valid uuid', async () => {
-        const res = await  request(server)
-            .get(`/wallets/${seed.walletC.id}`)
-            .set('treetracker-api-key', apiKey)
-            .set('content-type', 'application/json')
-            .set('Authorization', `Bearer ${bearerTokenA}`);
+  it('Get wallet by valid uuid', async () => {
+    const res = await request(server)
+      .get(`/wallets/${seed.walletC.id}`)
+      .set('treetracker-api-key', apiKey)
+      .set('content-type', 'application/json')
+      .set('Authorization', `Bearer ${bearerTokenA}`);
 
-        expect(res).property('statusCode').to.eq(200);
-    })
+    expect(res).property('statusCode').to.eq(200);
+  });
 
-    it('Get wallet by valid uuid which does not exist', async () => {
-        const res = await  request(server)
-            .get(`/wallets/00a6fa25-df29-4701-9077-557932591766`)
-            .set('treetracker-api-key', apiKey)
-            .set('content-type', 'application/json')
-            .set('Authorization', `Bearer ${bearerTokenA}`);
+  it('Get wallet by valid uuid which does not exist', async () => {
+    const res = await request(server)
+      .get(`/wallets/00a6fa25-df29-4701-9077-557932591766`)
+      .set('treetracker-api-key', apiKey)
+      .set('content-type', 'application/json')
+      .set('Authorization', `Bearer ${bearerTokenA}`);
 
-        expect(res).property('statusCode').to.eq(404);
-    })
-})
+    expect(res).property('statusCode').to.eq(404);
+  });
+});

--- a/__tests__/wallet-get.spec.js
+++ b/__tests__/wallet-get.spec.js
@@ -116,7 +116,7 @@ describe('Wallet: Get wallets of an account', () => {
 
         expect(res).property('statusCode').to.eq(200);
         expect(res.body.total).to.eq(11);
-        expect(res.body.query.offset).to.eq('0');
+        expect(res.body.query.offset).to.eq(0);
 
         const resB = await request(server)
             .get('/wallets')

--- a/__tests__/wallet-get.spec.js
+++ b/__tests__/wallet-get.spec.js
@@ -127,7 +127,7 @@ describe('Wallet: Get wallets of an account', () => {
 
         expect(resB).property('statusCode').to.eq(200);
         expect(resB.body.total).to.eq(11);
-        expect(resB.body.query.offset).to.eq('2');
+        expect(resB.body.query.offset).to.eq(2);
 
         const resC = await request(server)
             .get('/wallets')
@@ -137,8 +137,8 @@ describe('Wallet: Get wallets of an account', () => {
             .set('Authorization', `Bearer ${bearerTokenA}`);
         expect(resC).property('statusCode').to.eq(200);
         expect(resC.body.total).to.eq(11);
-        expect(resC.body.query.offset).to.eq('0');
-        expect(resC.body.query.limit).to.eq('2');
+        expect(resC.body.query.offset).to.eq(0);
+        expect(resC.body.query.limit).to.eq(2);
     })
 
     it('Get wallet by valid uuid', async () => {

--- a/server/repositories/WalletRepository.js
+++ b/server/repositories/WalletRepository.js
@@ -98,6 +98,9 @@ class WalletRepository extends BaseRepository {
 
     query = query.union(union1, union2);
 
+    // get the total count (before applying limit and offset options)
+    const count = await this._session.getDB().from(query.as('p')).count('*');
+
     if (limitOptions && limitOptions.limit) {
       query = query.limit(limitOptions.limit);
     }
@@ -107,11 +110,10 @@ class WalletRepository extends BaseRepository {
     }
 
     const wallets = await query;
-    if (getCount) {
-      const count = await this._session.getDB().from(query.as('p')).count('*');
+    Joi.assert(wallets, Joi.array().required());
 
+    if(getCount)
       return { wallets, count: +count[0].count };
-    }
 
     return { wallets };
   }

--- a/server/repositories/WalletRepository.js
+++ b/server/repositories/WalletRepository.js
@@ -98,8 +98,11 @@ class WalletRepository extends BaseRepository {
 
     query = query.union(union1, union2);
 
-    // get the total count (before applying limit and offset options)
-    const count = await this._session.getDB().from(query.as('p')).count('*');
+
+    let count;
+    if(getCount)
+    // total count query (before applying limit and offset options)
+    count = await this._session.getDB().from(query.as('p')).count('*');
 
     if (limitOptions && limitOptions.limit) {
       query = query.limit(limitOptions.limit);
@@ -110,10 +113,10 @@ class WalletRepository extends BaseRepository {
     }
 
     const wallets = await query;
-    Joi.assert(wallets, Joi.array().required());
 
-    if(getCount)
-      return { wallets, count: +count[0].count };
+    if(getCount) {
+      return {wallets, count: +count[0].count};
+    }
 
     return { wallets };
   }

--- a/server/repositories/WalletRepository.js
+++ b/server/repositories/WalletRepository.js
@@ -14,9 +14,14 @@ class WalletRepository extends BaseRepository {
   }
 
   async getByName(wallet) {
-      Joi.assert(wallet, Joi.string().pattern(/^\S+$/).messages({
-        'string.pattern.base': `Invalid wallet name: "${wallet}"`
-      }) );
+    Joi.assert(
+      wallet,
+      Joi.string()
+        .pattern(/^\S+$/)
+        .messages({
+          'string.pattern.base': `Invalid wallet name: "${wallet}"`,
+        }),
+    );
 
     const list = await this._session
       .getDB()
@@ -27,7 +32,10 @@ class WalletRepository extends BaseRepository {
     try {
       Joi.assert(list, Joi.array().required().length(1));
     } catch (error) {
-      throw new HttpError(404, `Could not find entity by wallet name: ${wallet}`);
+      throw new HttpError(
+        404,
+        `Could not find entity by wallet name: ${wallet}`,
+      );
     }
     return list[0];
   }
@@ -96,11 +104,11 @@ class WalletRepository extends BaseRepository {
 
     query = query.union(union1, union2);
 
-
-    let count;
-    if(getCount)
     // total count query (before applying limit and offset options)
-    count = await this._session.getDB().from(query.as('p')).count('*');
+    const countQuery = this._session
+      .getDB()
+      .from(query.clone().as('q'))
+      .count('*');
 
     if (limitOptions && limitOptions.limit) {
       query = query.limit(limitOptions.limit);
@@ -112,8 +120,9 @@ class WalletRepository extends BaseRepository {
 
     const wallets = await query;
 
-    if(getCount) {
-      return {wallets, count: +count[0].count};
+    if (getCount) {
+      const count = await countQuery;
+      return { wallets, count: +count[0].count };
     }
 
     return { wallets };

--- a/server/repositories/WalletRepository.spec.js
+++ b/server/repositories/WalletRepository.spec.js
@@ -89,12 +89,12 @@ describe('WalletRepository', () => {
         expect(query.sql).match(
           /select.*wallet.*where.*actor_wallet_id.*request_type.*/,
         );
-        query.response([{ id: 1 }]);
+        query.response([{ count: 1 }]);
       } else if (step === 2) {
         expect(query.sql).match(
           /select.*wallet.*where.*actor_wallet_id.*request_type.*name.*limit.*/,
         );
-        query.response([{ count: 1 }]);
+        query.response([{ id: 1 }]);
       }
     });
     const entity = await walletRepository.getAllWallets(

--- a/server/repositories/WalletRepository.spec.js
+++ b/server/repositories/WalletRepository.spec.js
@@ -89,12 +89,12 @@ describe('WalletRepository', () => {
         expect(query.sql).match(
           /select.*wallet.*where.*actor_wallet_id.*request_type.*/,
         );
-        query.response([{ count: 1 }]);
+        query.response([{ id: 1 }]);
       } else if (step === 2) {
         expect(query.sql).match(
-          /select.*wallet.*where.*actor_wallet_id.*request_type.*name.*limit.*/,
+          /select.*count.*where.*actor_wallet_id.*request_type.*name.*/,
         );
-        query.response([{ id: 1 }]);
+        query.response([{ count: 1 }]);
       }
     });
     const entity = await walletRepository.getAllWallets(


### PR DESCRIPTION
## Description
GET `/wallets` returns the correct `total` field in the response object. 

**Issue(s) addressed**
- Resolves #419.

**What kind of change(s) does this PR introduce?**

- [ ] Enhancement
- [X] Bug fix
- [ ] Refactor

**Please check if the PR fulfils these requirements**

- [X] The commit message follows our guidelines
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)

## Issue

**What is the current behavior?**
The `total` currently returned is the same as the `limit` parameter. It should be the total number of objects that match the input parameters instead.

**What is the new behavior?**
The `total` field returns the correct value.

## Breaking change

**Does this PR introduce a breaking change?**
No.

## Other useful information
None.