### PR TITLE
V1.10 Fix /tokens/:id/transactions returns correct fields

### DIFF
--- a/server/models/Wallet.spec.js
+++ b/server/models/Wallet.spec.js
@@ -835,7 +835,7 @@ describe("Wallet", () => {
       sinon.stub(Wallet.prototype, "hasControlOver").resolves(true);
       await jestExpect(async () => {
         await wallet.fulfillTransferWithTokens(1, [token]);
-      }).rejects.toThrow(/no need/i);
+      }).rejects.toThrow(/Do not specify token IDs/i);
     });
 
     it("Too many tokens", async () => {
@@ -1330,7 +1330,7 @@ describe("Wallet", () => {
       sinon.stub(Wallet.prototype, "getTransfers").resolves([]);
       await jestExpect(async () => {
         await wallet.getTransferById(1);
-      }).rejects.toThrow(/not find/);
+      }).rejects.toThrow(/Transfer does not exist/);
     });
   });
 

--- a/server/routes/transferRouter.spec.js
+++ b/server/routes/transferRouter.spec.js
@@ -328,7 +328,7 @@ describe("transferRouter", () => {
         .send({
         });
       expect(res).property("statusCode").eq(422);
-      expect(res.body.message).match(/implicit.*required/i);
+      expect(res.body.message).match(/implicit property/i);
     });
 
     it("Duplicated token uuid should throw error", async () => {

--- a/server/services/TokenService.js
+++ b/server/services/TokenService.js
@@ -73,7 +73,7 @@ class TokenService{
     {
       const token = await this.getById(token_id);
       const json = await token.toJSON();
-      result.token = json.uuid;
+      result.token = json.id;
     }
     {
       const wallet = await this.walletService.getById(source_wallet_id);

--- a/server/services/TokenService.spec.js
+++ b/server/services/TokenService.spec.js
@@ -80,7 +80,6 @@ describe("Token", () => {
     }
     sinon.stub(TokenService.prototype, "getById").resolves(new Token({
       id: tokenId1,
-      uuid: "xxx",
       capture_id: captureId1,
     }));
     sinon.stub(WalletService.prototype, "getById").resolves(new Wallet({
@@ -88,7 +87,7 @@ describe("Token", () => {
       name: "testName",
     }));
     const result = await tokenService.convertToResponse(transactionObject);
-    expect(result).property("token").eq("xxx");
+    expect(result).property("token").eq(tokenId1);
     expect(result).property("sender_wallet").eq("testName");
     expect(result).property("receiver_wallet").eq("testName");
   });


### PR DESCRIPTION
## Description
<!-- Add a brief description of the changes -->
The endpoint `/tokens/:id/transactions` now returns 'token' as per the specification.

**Issue(s) addressed**
<!-- List resolved issues here, e.g. Resolves #123 (one issue per line) -->
- Resolves #425 

**What kind of change(s) does this PR introduce?**
<!-- Tick all that apply by replacing [ ] with [x] -->

- [ ] Enhancement
- [X] Bug fix
- [X] Refactor

**Please check if the PR fulfils these requirements**
<!-- Tick all that apply by replacing [ ] with [x] -->
<!-- You are responsible for adding/updating tests for your changes. -->

- [X] The commit message follows our guidelines
- [X] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)

## Issue

**What is the current behavior?**
The endpoint doesn't return 'token' field.

**What is the new behavior?**
<!-- Include screenshots or videos if the UI has changed. -->
The endpoint returns the correct fields.
![image](https://github.com/Greenstand/treetracker-wallet-api/assets/15161954/d986c8e6-3b5c-411e-b177-107e02d2e52e)


## Breaking change

**Does this PR introduce a breaking change?**
No.

## Other useful information
<!-- Is anything in the issue not covered by this PR? -->
<!-- Is there a dependency on another issue or PR? -->
None.