### PR TITLE
fix:get all token ids from wallet

### DIFF
--- a/__tests__/get-tokens.spec.js
+++ b/__tests__/get-tokens.spec.js
@@ -103,6 +103,17 @@ describe('GET tokens', () => {
     expect(res.body.tokens[0].id).eq(seed.token.id);
   });
 
+  it(`GET /tokens/ should return correct limit on large limit`, async () => {
+    await seed.addMultipleTokensToWallet(seed.wallet.id,3000);
+    const res = await request(server)
+      .get(`/tokens?limit=3000`)
+      .set('treetracker-api-key', seed.apiKey)
+      .set('Authorization', `Bearer ${bearerToken}`);
+
+    expect(res).to.have.property('statusCode', 200);
+    expect(res.body.tokens.length).to.eq(3000);
+  });
+
   it(`GET /tokens/ should return correct offset`, async () => {
     const insertedId = (await seed.addTokenToWallet(seed.wallet.id))[0].id;
     const res = await request(server)

--- a/__tests__/seed.js
+++ b/__tests__/seed.js
@@ -97,7 +97,6 @@ async function seed() {
     salt: 'test',
     name: 'test',
   });
-
   // wallet
   await knex('wallet').insert({
     id: wallet.id,
@@ -154,6 +153,19 @@ async function addTokenToWallet(walletId) {
   );
 }
 
+async function addMultipleTokensToWallet(walletId, numberOfTokens) {
+  const tokens = [];
+
+  for (let i = 0; i < numberOfTokens; i=i+1) {
+    tokens.push({
+      id: uuid.v4(),
+      capture_id: uuid.v4(),
+      wallet_id: walletId,
+    });
+  }
+  await knex.batchInsert('token', tokens);
+}
+
 async function clear() {
   log.debug('clear tables');
   await knex('api_key').del();
@@ -176,4 +188,5 @@ module.exports = {
   tokenB,
   captureB,
   addTokenToWallet,
+  addMultipleTokensToWallet,
 };

--- a/server/handlers/tokenHandler/schemas.js
+++ b/server/handlers/tokenHandler/schemas.js
@@ -1,7 +1,7 @@
 const Joi = require('joi');
 
 const tokenGetSchema = Joi.object({
-  limit: Joi.number().integer().min(1).max(2000).default(2000),
+  limit: Joi.number().integer().min(1).default(2000),
   offset: Joi.number().integer().min(0).default(0),
   wallet: Joi.string(),
 });


### PR DESCRIPTION
## Description
<!-- Add a brief description of the changes -->

**Issue(s) addressed**
<!-- List resolved issues here, e.g. Resolves #123 (one issue per line) -->
- Resolves #455

**What kind of change(s) does this PR introduce?**
<!-- Tick all that apply by replacing [ ] with [x] -->

- [x] Enhancement
- [ ] Bug fix
- [ ] Refactor

**Please check if the PR fulfils these requirements**
<!-- Tick all that apply by replacing [ ] with [x] -->
<!-- You are responsible for adding/updating tests for your changes. -->

- [x] The commit message follows our guidelines
- [x] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)

## Issue

**What is the current behavior?**
The `/tokens?limit=` endpoint currently restricts the maximum number of tokens that can be retrieved to 2000. Requests exceeding this limit result in a validation error.

**What is the new behavior?**
Requests made to this route can now specify any limit value
## Breaking change

**Does this PR introduce a breaking change?**
No 
