### PR TITLE
fix count in get trust relationships

### DIFF
--- a/server/repositories/TrustRepository.js
+++ b/server/repositories/TrustRepository.js
@@ -118,6 +118,7 @@ async getAllByFilter(filter, limitOptions) {
     .orderBy('wallet_trust.id', 'asc'); 
 
   let derivedTable = this._session.getDB().select('*').from(subquery.as('subquery'));
+  
 
   let order = 'desc';
   let column = 'created_at';
@@ -133,6 +134,9 @@ async getAllByFilter(filter, limitOptions) {
 
   derivedTable = derivedTable.orderBy(column, order);
 
+  const count = await this._session.getDB().from(derivedTable.as('p')).count('*');
+
+
   if (limitOptions && limitOptions.limit) {
     derivedTable = derivedTable.limit(limitOptions.limit);
   }
@@ -142,9 +146,8 @@ async getAllByFilter(filter, limitOptions) {
 
   const result = await derivedTable;
 
-  const {count} = result[0];
+  return { result, count: +count[0].count };
 
-  return { result, count: +count };
 }
 }
 


### PR DESCRIPTION
## Description
<!-- Add a brief description of the changes -->
The count in trust relationships was returning null but now it is correctly returning total number of trust relationships
**Issue(s) addressed**
<!-- List resolved issues here, e.g. Resolves #123 (one issue per line) -->
- Resolves #

**What kind of change(s) does this PR introduce?**
<!-- Tick all that apply by replacing [ ] with [x] -->

- [ ] Enhancement
- [x ] Bug fix
- [ ] Refactor

**Please check if the PR fulfils these requirements**
<!-- Tick all that apply by replacing [ ] with [x] -->
<!-- You are responsible for adding/updating tests for your changes. -->

- [ ] The commit message follows our guidelines
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)

## Issue

**What is the current behavior?**

**What is the new behavior?**
<!-- Include screenshots or videos if the UI has changed. -->

## Breaking change

**Does this PR introduce a breaking change?**

## Other useful information
<!-- Is anything in the issue not covered by this PR? -->
<!-- Is there a dependency on another issue or PR? -->