### PR TITLE
fix: subwallets trust relationship validation

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "treetracker",
-  "version": "1.36.0",
+  "version": "1.38.1",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "treetracker",
-      "version": "1.36.0",
+      "version": "1.38.1",
       "license": "GPL-3.0-or-later",
       "dependencies": {
         "@aws-sdk/client-s3": "^3.556.0",

--- a/server/models/Trust.js
+++ b/server/models/Trust.js
@@ -27,7 +27,7 @@ class Trust {
     offset,
     limit,
     sort_by,
-    order
+    order,
   }) {
     const filter = {
       and: [
@@ -55,12 +55,18 @@ class Trust {
   /*
    * Get all trust relationships by filters, setting filter to undefined to allow all data
    */
-  async getAllTrustRelationships({ walletId, state, type, request_type, offset, limit, sort_by, order }) {
-    
+  async getAllTrustRelationships({
+    walletId,
+    state,
+    type,
+    request_type,
+    offset,
+    limit,
+    sort_by,
+    order,
+  }) {
     const filter = {
-      and: [
-        {'originator_wallet.id': walletId},
-      ],
+      and: [{ 'originator_wallet.id': walletId }],
     };
     if (state) {
       filter.and.push({ state });
@@ -71,7 +77,12 @@ class Trust {
     if (request_type) {
       filter.and.push({ request_type });
     }
-    return this._trustRepository.getAllByFilter(filter, { offset, limit, sort_by, order });
+    return this._trustRepository.getAllByFilter(filter, {
+      offset,
+      limit,
+      sort_by,
+      order,
+    });
   }
 
   /*
@@ -110,13 +121,41 @@ class Trust {
     //    }
 
     // check if the orginator can control the actor
-    const hasControl = await walletModel.hasControlOver(
+    const hasControlOverActor = await walletModel.hasControlOver(
       originatorWallet.id,
       actorWallet.id,
     );
 
-    if (!hasControl) {
+    // originating wallet has no permission to send request from actor wallet
+    if (!hasControlOverActor) {
       throw new HttpError(403, 'Have no permission to deal with this actor');
+    }
+
+    // check if originator can control the target
+    const hasControlOverTarget = await walletModel.hasControlOver(
+      originatorWallet.id,
+      targetWallet.id,
+    );
+
+    // cannot send trust relationship requests from one sub wallet to another
+    if (
+      originatorWallet.id !== actorWallet.id &&
+      originatorWallet.id !== targetWallet.id &&
+      hasControlOverActor &&
+      hasControlOverTarget
+    ) {
+      throw new HttpError(
+        409,
+        'Cannot send trust relationship request to a sub wallet with the same parent',
+      );
+    }
+
+    // originating wallet doesn't need to send requests to a sub wallet it manages
+    if (hasControlOverTarget) {
+      throw new HttpError(
+        409,
+        'The requesting wallet already manages the target wallet',
+      );
     }
 
     // check if the target wallet can accept the request


### PR DESCRIPTION
## Description
Better validation for requesting trust relationships.

**Issue(s) addressed**

**What kind of change(s) does this PR introduce?**
<!-- Tick all that apply by replacing [ ] with [x] -->

- [ ] Enhancement
- [x] Bug fix
- [ ] Refactor

**Please check if the PR fulfills these requirements**
<!-- Tick all that apply by replacing [ ] with [x] -->
<!-- You are responsible for adding/updating tests for your changes. -->

- [x] The commit message follows our guidelines
- [x] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)

## Issue

**What is the current behavior?**
Sub wallet is able to send a trust relationship request to another sub wallet with the same parent.

**What is the new behavior?**
<!-- Include screenshots or videos if the UI has changed. -->
- Sub wallets cannot send trust relationship requests to other sub wallets with the same parent.
- Better error message when a parent wallet tries to send a t.r. request to a sub wallet it already manages.  

## Breaking change

**Does this PR introduce a breaking change?**
None.

## Other useful information
<!-- Is anything in the issue not covered by this PR? -->
<!-- Is there a dependency on another issue or PR? -->
None.