### PR TITLE
Trust relationships ordering update

### DIFF
--- a/server/handlers/walletHandler/index.js
+++ b/server/handlers/walletHandler/index.js
@@ -74,30 +74,44 @@ const walletGetTrustRelationships = async (req, res) => {
   });
   const validatedQuery = await walletGetTrustRelationshipsSchema.validateAsync(
     req.query,
-    { abortEarly: false },
+    {
+      abortEarly: false,
+    },
   );
   const walletService = new WalletService();
 
   const { wallet_id: walletId } = validatedParams;
   const { wallet_id: loggedInWalletId } = req;
-    const sortBy = 'created_at';
-    const orderBy = 'desc';
-  const { state, type, request_type, limit, offset, sort_by, order, search  } = validatedQuery;
+  const sortBy = 'created_at';
+  const orderBy = 'desc';
+  const {
+    state,
+    type,
+    request_type,
+    limit,
+    offset,
+    sort_by,
+    order,
+    search,
+  } = validatedQuery;
 
-  const { wallets:managedWallets } = await walletService.getAllWallets(
+  const { wallets: managedWallets } = await walletService.getAllWallets(
     loggedInWalletId,
     {
-      limit:'10',
-      offset:'0',
+      limit: '1000',
+      offset: '0',
     },
     null,
     sortBy,
     orderBy,
     null,
-    null
+    null,
   );
   const trustService = new TrustService();
-  const {result: trust_relationships, count: total} = await trustService.getTrustRelationships(
+  const {
+    result: trust_relationships,
+    count: total,
+  } = await trustService.getTrustRelationships(
     loggedInWalletId,
     managedWallets,
     {
@@ -105,11 +119,11 @@ const walletGetTrustRelationships = async (req, res) => {
       state,
       type,
       request_type,
-      limit, 
-      offset, 
-      sort_by, 
+      limit,
+      offset,
+      sort_by,
       order,
-      search 
+      search,
     },
   );
   res.status(200).json({

--- a/server/models/Trust.js
+++ b/server/models/Trust.js
@@ -45,7 +45,7 @@ class Trust {
    */
   async getTrustRelationships({
     walletId,
-    managedWallets=[],
+    managedWallets = [],
     state,
     type,
     request_type,
@@ -55,13 +55,14 @@ class Trust {
     search,
     order,
   }) {
-    const managedWalletIds = managedWallets.map(wallet => wallet.id);
+    const managedWalletIds = managedWallets.map((wallet) => wallet.id);
+
     const orConditions = [
       { actor_wallet_id: walletId },
       { target_wallet_id: walletId },
       { originator_wallet_id: walletId },
     ];
-  
+
     managedWalletIds.forEach((managedWalletId) => {
       orConditions.push({ actor_wallet_id: managedWalletId });
       orConditions.push({ target_wallet_id: managedWalletId });
@@ -92,9 +93,19 @@ class Trust {
         ],
       });
     }
-    return this._trustRepository.getByFilter(filter, { offset, limit, sort_by, order });
+    return this._trustRepository.getByFilter(
+      filter,
+      {
+        offset,
+        limit,
+        sort_by,
+        order,
+      },
+      walletId,
+      managedWalletIds,
+    );
   }
-  
+
   async getTrustRelationshipsCount({ walletId, state, type, request_type }) {
     const filter = Trust.getTrustRelationshipFilter({
       walletId,
@@ -235,8 +246,8 @@ class Trust {
   // check if I (current wallet) can add a new trust like this
   async checkDuplicateRequest({ walletId, trustRelationship }) {
     let trustRelationships = await this.getTrustRelationships({ walletId });
-       if (trustRelationships.result) {
-        trustRelationships = trustRelationships.result;
+    if (trustRelationships.result) {
+      trustRelationships = trustRelationships.result;
     }
     if (
       trustRelationship.type ===
@@ -380,8 +391,10 @@ class Trust {
 
   async updateTrustState(trustRelationship, state) {
     const trustRelationshipToUpdate = { ...trustRelationship };
-    const now = new Date(); 
-    const formattedDate = `${(now.getMonth() + 1).toString().padStart(2, '0')}/${now
+    const now = new Date();
+    const formattedDate = `${(now.getMonth() + 1)
+      .toString()
+      .padStart(2, '0')}/${now
       .getDate()
       .toString()
       .padStart(2, '0')}/${now.getFullYear()}`;

--- a/server/models/Trust.spec.js
+++ b/server/models/Trust.spec.js
@@ -27,19 +27,19 @@ describe('Trust Model', () => {
 
   describe('getTrustRelationships', () => {
     const walletId = uuid();
-    const managedWallets = [{id: '90f8b2ab-c101-405d-922a-0a64dbe64ab6'}];
-    const managedWalletIds = managedWallets.map(wallet => wallet.id);
-  const orConditions = [
-    { actor_wallet_id: walletId },
-    { target_wallet_id: walletId },
-    { originator_wallet_id: walletId },
-  ];
+    const managedWallets = [{ id: '90f8b2ab-c101-405d-922a-0a64dbe64ab6' }];
+    const managedWalletIds = managedWallets.map((wallet) => wallet.id);
+    const orConditions = [
+      { actor_wallet_id: walletId },
+      { target_wallet_id: walletId },
+      { originator_wallet_id: walletId },
+    ];
 
-  managedWalletIds.forEach((managedWalletId) => {
-    orConditions.push({ actor_wallet_id: managedWalletId });
-    orConditions.push({ target_wallet_id: managedWalletId });
-    orConditions.push({ originator_wallet_id: managedWalletId });
-  });
+    managedWalletIds.forEach((managedWalletId) => {
+      orConditions.push({ actor_wallet_id: managedWalletId });
+      orConditions.push({ target_wallet_id: managedWalletId });
+      orConditions.push({ originator_wallet_id: managedWalletId });
+    });
     const filter = {
       and: [
         {
@@ -50,7 +50,7 @@ describe('Trust Model', () => {
 
     it('should get relationships', async () => {
       trustRepositoryStub.getByFilter.resolves(['relationship1']);
-    
+
       const result = await trustModel.getTrustRelationships({
         managedWallets,
         walletId,
@@ -59,12 +59,17 @@ describe('Trust Model', () => {
         offset: 1,
       });
       expect(result).eql(['relationship1']);
-      expect(trustRepositoryStub.getByFilter).calledOnceWithExactly(filter, {
-        limit: 10,
-        offset: 1,
-        order: undefined,
-        sort_by: undefined
-      });
+      expect(trustRepositoryStub.getByFilter).calledOnceWithExactly(
+        filter,
+        {
+          limit: 10,
+          offset: 1,
+          order: undefined,
+          sort_by: undefined,
+        },
+        walletId,
+        managedWalletIds,
+      );
     });
 
     it('should get relationships -- state', async () => {
@@ -85,8 +90,10 @@ describe('Trust Model', () => {
           limit: 10,
           offset: 1,
           order: undefined,
-          sort_by: undefined
+          sort_by: undefined,
         },
+        walletId,
+        managedWalletIds,
       );
     });
 
@@ -109,8 +116,10 @@ describe('Trust Model', () => {
           limit: 10,
           offset: 11,
           order: undefined,
-          sort_by: undefined
+          sort_by: undefined,
         },
+        walletId,
+        managedWalletIds,
       );
     });
 
@@ -133,8 +142,10 @@ describe('Trust Model', () => {
           limit: 101,
           offset: 1,
           order: undefined,
-          sort_by: undefined
+          sort_by: undefined,
         },
+        walletId,
+        managedWalletIds,
       );
     });
 
@@ -161,8 +172,10 @@ describe('Trust Model', () => {
           limit: 100,
           offset: 0,
           order: undefined,
-          sort_by: undefined
+          sort_by: undefined,
         },
+        walletId,
+        managedWalletIds,
       );
     });
   });
@@ -739,12 +752,13 @@ describe('Trust Model', () => {
   it('updateTrustState', async () => {
     trustRepositoryStub.update.resolves({ status: 'updated' });
 
-    const now = new Date(); 
-    const formattedDate = `${(now.getMonth() + 1).toString().padStart(2, '0')}/${now
+    const now = new Date();
+    const formattedDate = `${(now.getMonth() + 1)
+      .toString()
+      .padStart(2, '0')}/${now
       .getDate()
       .toString()
       .padStart(2, '0')}/${now.getFullYear()}`;
-
 
     const result = await trustModel.updateTrustState(
       {
@@ -767,7 +781,7 @@ describe('Trust Model', () => {
     expect(trustRepositoryStub.update).calledOnceWithExactly({
       id: 'trustId',
       state: 'new state',
-      updated_at: formattedDate
+      updated_at: formattedDate,
     });
   });
 
@@ -910,7 +924,7 @@ describe('Trust Model', () => {
     });
 
     it('should error out -- no permission to accept', async () => {
-      trustRepositoryStub.getByFilter.resolves({count: 0, result: []});
+      trustRepositoryStub.getByFilter.resolves({ count: 0, result: [] });
       const trustRelationshipId = uuid();
       const walletId = uuid();
 
@@ -938,9 +952,10 @@ describe('Trust Model', () => {
       const trustRelationshipId = uuid();
       const walletId = uuid();
 
-      trustRepositoryStub.getByFilter.resolves({count: 1, result:[
-        { originator_wallet_id: walletId, id: trustRelationshipId },
-      ]});
+      trustRepositoryStub.getByFilter.resolves({
+        count: 1,
+        result: [{ originator_wallet_id: walletId, id: trustRelationshipId }],
+      });
       updateTrustStateStub.resolves('state cancelled');
       const result = await trustModel.cancelTrustRequest({
         trustRelationshipId,

--- a/server/repositories/TrustRepository.js
+++ b/server/repositories/TrustRepository.js
@@ -96,7 +96,8 @@ class TrustRepository extends BaseRepository {
       }
     }
 
-    // order by priority (which is requested state)
+    // order by new column priority
+    // priority is 1 when state is requested and
     // target is current wallet or one of its managed wallets
     if (managedWalletIds.length > 0 && loggedInWalletId) {
       promise = promise.select(
@@ -114,13 +115,18 @@ class TrustRepository extends BaseRepository {
       promise = promise.orderBy([
         { column: 'priority', order: 'desc' },
         { column, order }, // secondary
+        { column: 'id', order }, // tertiary sort, prevent duplicate records among pages
       ]);
     } else {
       // normal ordering for other endpoints
       promise = promise.orderBy(column, order);
     }
 
-    const result = await promise;
+    let result = await promise;
+
+    // remove priority column from result
+    // eslint-disable-next-line no-unused-vars
+    result = result.map(({ priority, ...rest }) => rest);
 
     return { result, count: +count[0].count };
   }

--- a/server/services/TrustService.js
+++ b/server/services/TrustService.js
@@ -16,7 +16,17 @@ class TrustService {
   async getTrustRelationships(
     loggedInWalletId,
     managedWallets,
-    { walletId, state, type, request_type, offset, limit,sort_by, order, search },
+    {
+      walletId,
+      state,
+      type,
+      request_type,
+      offset,
+      limit,
+      sort_by,
+      order,
+      search,
+    },
   ) {
     // check if wallet exists first
     // throws error if no wallet matching walletId exists
@@ -43,7 +53,7 @@ class TrustService {
       limit,
       sort_by,
       order,
-      search
+      search,
     });
 
     // const count = await this._trust.getTrustRelationshipsCount({
@@ -58,7 +68,13 @@ class TrustService {
 
   // limit and offset not feasible using the current implementation
   // except if done manually or coming up with a single query
-  async getAllTrustRelationships({ walletId, state, type, request_type, search }) {
+  async getAllTrustRelationships({
+    walletId,
+    state,
+    type,
+    request_type,
+    search,
+  }) {
     const walletModel = new Wallet(this._session);
     const { wallets } = await walletModel.getAllWallets(
       walletId,
@@ -72,13 +88,17 @@ class TrustService {
     const managedWallets = [];
     await Promise.all(
       wallets.map(async (w) => {
-        const trustRelationships = await this.getTrustRelationships(walletId, managedWallets,{
-          walletId: w.id,
-          state,
-          type,
-          request_type,
-          search
-        });
+        const trustRelationships = await this.getTrustRelationships(
+          walletId,
+          managedWallets,
+          {
+            walletId: w.id,
+            state,
+            type,
+            request_type,
+            search,
+          },
+        );
         alltrustRelationships.push(...trustRelationships.result);
       }),
     );


### PR DESCRIPTION
## Description
Updated the ordering of endpoint `GET /wallets/{wallet_id}/trust_relationships` to display `requested` state records at the top of the returned results.

**What kind of change(s) does this PR introduce?**
<!-- Tick all that apply by replacing [ ] with [x] -->

- [x] Enhancement
- [ ] Bug fix
- [ ] Refactor

**Please check if the PR fulfils these requirements**
<!-- Tick all that apply by replacing [ ] with [x] -->
<!-- You are responsible for adding/updating tests for your changes. -->

- [x] The commit message follows our guidelines
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)

## Issue

**What is the current behavior?**
The endpoint returns results without prioritizing records by `requested` state.

**What is the new behavior?**
<!-- Include screenshots or videos if the UI has changed. -->
Records with state `requested` and `target_wallet` as the current wallet or one of its managed wallets will be returned at the top of the results.

## Breaking change

**Does this PR introduce a breaking change?**
No.

## Other useful information
<!-- Is anything in the issue not covered by this PR? -->
<!-- Is there a dependency on another issue or PR? -->
None.