### PR TITLE
fix: bump up pg version to 13

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -2,7 +2,7 @@ version: '3.1'
 
 services: 
   db: 
-    image: postgres:9-alpine
+    image: postgres:13-alpine
     restart: always
     environment:
       - POSTGRES_USER=wallet_user

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "treetracker",
-  "version": "1.38.1",
+  "version": "1.41.0",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "treetracker",
-      "version": "1.38.1",
+      "version": "1.41.0",
       "license": "GPL-3.0-or-later",
       "dependencies": {
         "@aws-sdk/client-s3": "^3.556.0",


### PR DESCRIPTION
## Description
Bump pg version to 13 to consistent with production

**What kind of change(s) does this PR introduce?**
<!-- Tick all that apply by replacing [ ] with [x] -->

- [ ] Enhancement
- [x] Bug fix
- [ ] Refactor

**Please check if the PR fulfils these requirements**
<!-- Tick all that apply by replacing [ ] with [x] -->
<!-- You are responsible for adding/updating tests for your changes. -->

- [x] The commit message follows our guidelines
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)

## Issue

**What is the current behavior?**
In current pg version, when data migration, below error will throw out
```
error: ALTER TYPE ... ADD cannot run inside a transaction block
```
which caused by pg version is too low https://stackoverflow.com/questions/53149484/error-alter-type-add-cannot-run-inside-a-transaction-block

After confirming with @dadiorchen , our production is using pg `13`

**What is the new behavior?**
<!-- Include screenshots or videos if the UI has changed. -->
no problem to run ` ../node_modules/db-migrate/bin/db-migrate --env dev up` locally, no error throws out anymore
## Breaking change

**Does this PR introduce a breaking change?**
If you are using old pg `9` and want to keep existing data, please export db and upgrade db and import again

## Other useful information
After upgrading to pg 13, please follow https://github.com/Greenstand/treetracker-wallet-api?tab=readme-ov-file#database-setup to setup local db again