### PR TITLE
fix: use wildcard patterns for private key exclusions in .gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,18 +1,16 @@
 node_modules/
 config/
+
 # Keys
 *.key
 *.key.pub
 *.pem
-private.key
-public.key
-jwtRS256.key
-jwtRS256.key.pub
 keygen.sh
 database.json
-.env
-.env.test
-.env.development
+
+# Environment variables
+.env*
+
 .vscode
 .nyc_output
 tmp/

--- a/.gitignore
+++ b/.gitignore
@@ -1,5 +1,9 @@
 node_modules/
 config/
+# Keys
+*.key
+*.key.pub
+*.pem
 private.key
 public.key
 jwtRS256.key


### PR DESCRIPTION
## What
Adds wildcard patterns `*.key`, `*.key.pub`, and `*.pem` to `.gitignore`, alongside the existing specific key filename entries.

## Why
The current `.gitignore` excludes private keys by exact filename:

- private.key
- public.key
- jwtRS256.key
- jwtRS256.key.pub

This only works if contributors generate keys using those exact names. Any variation (e.g. `jwtRS512.key`, `server.pem`, `rsa.key`) would not be caught and could be committed unintentionally.

`.pem` files are a common private key format not covered at all by the current entries.

The existing specific filenames are kept for clarity.

## Type of change
- Bug fix (non-breaking change which fixes an issue)

## Change
Added to `.gitignore`:
*.key
*.key.pub
*.pem
