### PR TITLE
Draft: [Do Not Merge] Stripe POC

### DIFF
--- a/server/app.js
+++ b/server/app.js
@@ -33,20 +33,25 @@ app.use(
       }
       return next();
     }
-    if (
-      req.method === 'POST' ||
-      req.method === 'PATCH' ||
-      req.method === 'PUT'
-    ) {
-      if (req.headers['content-type'] !== 'application/json') {
-        throw new HttpError(
-          415,
-          'Invalid content type. API only supports application/json',
-        );
-      }
-    }
+    // if (
+    //   req.method === 'POST' ||
+    //   req.method === 'PATCH' ||
+    //   req.method === 'PUT'
+    // ) {
+    //   if (req.headers['content-type'] !== 'application/json') {
+    //     throw new HttpError(
+    //       415,
+    //       'Invalid content type. API only supports application/json',
+    //     );
+    //   }
+    // }
     next();
   }),
+);
+
+app.use(
+  '/stripe/verifyCheckout',
+  express.raw({ type: 'application/json' })
 );
 
 app.use(express.urlencoded({ extended: false })); // parse application/x-www-form-urlencoded

--- a/server/repositories/StripeTransactionRepository.js
+++ b/server/repositories/StripeTransactionRepository.js
@@ -1,6 +1,3 @@
-const Joi = require('joi');
-const HttpError = require('../utils/HttpError');
-const TrustRelationshipEnums = require('../utils/trust-enums');
 const BaseRepository = require('./BaseRepository');
 
 class StripeTransactionRepository extends BaseRepository {
@@ -40,7 +37,7 @@ class StripeTransactionRepository extends BaseRepository {
 
     async updateStatus(id, status) {
         if (['FAILED', 'CANCELLED', 'PAID'].includes(status)){
-            return
+            return undefined
         }
 
         const object = {status, update_at: undefined}
@@ -53,7 +50,7 @@ class StripeTransactionRepository extends BaseRepository {
                 .returning('*');
             }) 
 
-            return result[0];
+        return result[0];
     }
 }
 

--- a/server/repositories/StripeTransactionRepository.js
+++ b/server/repositories/StripeTransactionRepository.js
@@ -36,19 +36,17 @@ class StripeTransactionRepository extends BaseRepository {
     }
 
     async updateStatus(id, status) {
-        if (['FAILED', 'CANCELLED', 'PAID'].includes(status)){
+        if (!(['FAILED', 'CANCELLED', 'PAID'].includes(status))){
             return undefined
         }
 
-        const object = {status, update_at: undefined}
+        const object = {status, updated_at: new Date()}
         const result = await this._session
             .getDB()
-            .with('updated', (qb) => {
-                qb.update(object)
-                .into(this._tableName)
-                .where('id', id)
-                .returning('*');
-            }) 
+            .update(object)
+            .into(this._tableName)
+            .where('id', id)
+            .returning('*')
 
         return result[0];
     }

--- a/server/repositories/StripeTransactionRepository.js
+++ b/server/repositories/StripeTransactionRepository.js
@@ -1,0 +1,87 @@
+const Joi = require('joi');
+const HttpError = require('../utils/HttpError');
+const TrustRelationshipEnums = require('../utils/trust-enums');
+const BaseRepository = require('./BaseRepository');
+
+class StripeTransactionRepository extends BaseRepository {
+    constructor(session) {
+        super('public.stripe_transaction', session);
+        this._tableName = 'public.stripe_transaction';
+        this._session = session;
+    }
+
+    async getById(id){
+        const stripeUser = await this._session
+            .getDB()
+            .select()
+            .table(this._tableName)
+            .where('id', id)
+            .first();
+        
+        return stripeUser
+    }
+
+    async create(stripeUserId) {
+        const object = {
+            stripe_user_id: stripeUserId, 
+            status: 'PENDING'
+        }
+        
+        const result = await this._session
+            .getDB()
+            .with('inserted', (qb) => {
+                qb.insert(object).into(this._tableName).returning('*');
+            })
+            .select('*').
+            from('inserted');
+    
+        return result[0];
+    }
+
+    async updateStatus(id, status) {
+        if (['FAILED', 'CANCELLED', 'PAID'].includes(status)){
+            return
+        }
+
+        const object = {status, update_at: undefined}
+        const result = await this._session
+            .getDB()
+            .with('updated', (qb) => {
+                qb.update(object)
+                .into(this._tableName)
+                .where('id', id)
+                .returning('*');
+            }) 
+
+            return result[0];
+    }
+}
+
+module.exports = StripeTransactionRepository
+
+
+/*
+CREATE TYPE stripe_transaction_status AS ENUM (
+    'PENDING',
+    'FAILED',
+    'CANCELLED',
+    'PAID'
+);
+
+CREATE TABLE stripe_transaction (
+    id UUID PRIMARY KEY DEFAULT gen_random_uuid(),
+
+    stripe_user_id INTEGER NOT NULL,
+
+    status stripe_transaction_status NOT NULL DEFAULT 'PENDING',
+
+    created_at TIMESTAMPTZ NOT NULL DEFAULT NOW(),
+    updated_at TIMESTAMPTZ NOT NULL DEFAULT NOW()
+);
+
+ALTER TABLE stripe_transaction_history
+ADD CONSTRAINT fk_stripe_user
+FOREIGN KEY (stripe_user_id)
+REFERENCES stripe_user(id)
+ON DELETE CASCADE;
+*/

--- a/server/repositories/StripeUserRepository.js
+++ b/server/repositories/StripeUserRepository.js
@@ -1,0 +1,62 @@
+const Joi = require('joi');
+const HttpError = require('../utils/HttpError');
+const TrustRelationshipEnums = require('../utils/trust-enums');
+const BaseRepository = require('./BaseRepository');
+
+class StripeUserRepository extends BaseRepository {
+    constructor(session) {
+        super('public.stripe_user', session);
+        this._tableName = 'public.stripe_user';
+        this._session = session;
+    }
+
+    async getByUserId(userId){
+        const stripeUser = await this._session
+            .getDB()
+            .select()
+            .table(this._tableName)
+            .where('user_id', userId)
+            .first();
+        
+        return stripeUser
+    }
+
+    async create(userId, stripeCustomerId) {
+        const object = {
+            user_id: userId, 
+            stripe_customer_id: stripeCustomerId,
+        }
+        const result = await this._session
+            .getDB()
+            .with('inserted', (qb) => {
+                qb.insert(object).into(this._tableName).returning('*');
+            })
+            .select('*').
+            from('inserted');
+    
+        return result[0];
+    }
+}
+
+module.exports = StripeUserRepository
+
+
+/*
+CREATE TABLE stripe_user (
+    id SERIAL PRIMARY KEY,
+
+    user_id INTEGER NOT NULL,
+    stripe_customer_id TEXT NOT NULL,
+
+    created_at TIMESTAMPTZ NOT NULL DEFAULT NOW(),
+    updated_at TIMESTAMPTZ NOT NULL DEFAULT NOW(),
+
+    deleted_at TIMESTAMPTZ NULL
+);
+
+CREATE INDEX idx_stripe_user_user_id
+ON stripe_user (user_id);
+
+CREATE INDEX idx_stripe_user_stripe_customer_id
+ON stripe_user (stripe_customer_id);
+*/

--- a/server/repositories/StripeUserRepository.js
+++ b/server/repositories/StripeUserRepository.js
@@ -1,6 +1,3 @@
-const Joi = require('joi');
-const HttpError = require('../utils/HttpError');
-const TrustRelationshipEnums = require('../utils/trust-enums');
 const BaseRepository = require('./BaseRepository');
 
 class StripeUserRepository extends BaseRepository {

--- a/server/routes/index.js
+++ b/server/routes/index.js
@@ -5,4 +5,5 @@ module.exports = [
   require('./trustRouter'),
   require('./walletRouter'),
   require('./eventRouter'),
+  require('./stripeRouter')
 ];

--- a/server/routes/stripeRouter.js
+++ b/server/routes/stripeRouter.js
@@ -10,12 +10,14 @@ const createCheckout = async (req, res) => {
 }
 
 const verifyCheckout = async (req, res) => {
-    await new StripeService(123).verifyCheckout()
+    const webhookData = req.body;
+    const dataSignature = req.headers['stripe-signature']
+    await new StripeService(123).verifyCheckout(webhookData, dataSignature)
     res.status(200).json({});
 }
 
 router.get('/getCheckout', createCheckout);
-router.get('/verifyCheckout', verifyCheckout);
+router.post('/verifyCheckout', verifyCheckout);
 
 routerWrapper.use('/stripe', router);
 module.exports = routerWrapper;

--- a/server/routes/stripeRouter.js
+++ b/server/routes/stripeRouter.js
@@ -1,13 +1,8 @@
-const StripeService = require('../services/StripeService')
 const express = require('express');
+const StripeService = require('../services/StripeService')
 
 const router = express.Router();
 const routerWrapper = express.Router();
-const {
-  handlerWrapper,
-  verifyJWTHandler,
-  apiKeyHandler,
-} = require('../utils/utils');
 
 const createCheckout = async (req, res) => {
     const checkoutUrl = await new StripeService(123).createCheckout()

--- a/server/routes/stripeRouter.js
+++ b/server/routes/stripeRouter.js
@@ -1,0 +1,26 @@
+const StripeService = require('../services/StripeService')
+const express = require('express');
+
+const router = express.Router();
+const routerWrapper = express.Router();
+const {
+  handlerWrapper,
+  verifyJWTHandler,
+  apiKeyHandler,
+} = require('../utils/utils');
+
+const createCheckout = async (req, res) => {
+    const checkoutUrl = await new StripeService(123).createCheckout()
+    res.status(200).json(checkoutUrl);
+}
+
+const verifyCheckout = async (req, res) => {
+    await new StripeService(123).verifyCheckout()
+    res.status(200).json({});
+}
+
+router.get('/getCheckout', createCheckout);
+router.get('/verifyCheckout', verifyCheckout);
+
+routerWrapper.use('/stripe', router);
+module.exports = routerWrapper;

--- a/server/services/StripeService.js
+++ b/server/services/StripeService.js
@@ -16,31 +16,33 @@ class StripeService {
         this._stripeTransactionRepo = new StripeTransactionRepository(this._session)
     }
 
-    #getOrCreateStripeUser = async () => {
+    async __getOrCreateStripeUser() {
         let stripeUser = await this._stripeUserRepo.getByUserId(this.userId)
         if (!stripeUser){
             // In reality, we should be getting this from the user record
             const userInfo = {name: 'Test User', email: 'testuser@test.com'}
             const customer = await stripe.customers.create(userInfo);
 
-            const stripeCustomerId = customer["id"]
+            const stripeCustomerId = customer.id
             stripeUser = await this._stripeUserRepo.create(this.userId, stripeCustomerId)
         }
 
         return stripeUser
     }
 
-    #createTransaction = async (stripeUserId) => {
-        return await this._stripeTransactionRepo.create(stripeUserId)
+    async __createTransaction(stripeUserId) {
+        const transaction = await this._stripeTransactionRepo.create(stripeUserId)
+        return transaction
     }
 
-    #updateTransaction = async (transactionId, status) => {
-        return await this._stripeTransactionRepo.updateStatus(transactionId, status)
+    async __updateTransaction(transactionId, status) {
+        const transaction = await this._stripeTransactionRepo.updateStatus(transactionId, status)
+        return transaction
     }
 
-    createCheckout = async (metaInfo={}) => {
-        const stripeUser = await this.#getOrCreateStripeUser()
-        const stripeTransaction = await this.#createTransaction(stripeUser.id)
+    async createCheckout(metaInfo={}) {
+        const stripeUser = await this.__getOrCreateStripeUser()
+        const stripeTransaction = await this.__createTransaction(stripeUser.id)
 
         const checkoutSession = await stripe.checkout.sessions.create({
             mode: 'payment',
@@ -57,14 +59,12 @@ class StripeService {
             ],
         });
 
-        console.log(checkoutSession)
-
-        return checkoutSession["url"]
+        return checkoutSession.url
     }
     
-    verifyCheckout = async (webhookData) => {
-        const transactionId = webhookData["object"]["client_reference_id"]
-        await this.#updateTransaction(transactionId, 'PAID')
+    async verifyCheckout(webhookData) {
+        const transactionId = webhookData.object.client_reference_id
+        await this.__updateTransaction(transactionId, 'PAID')
     }
 }
 

--- a/server/services/StripeService.js
+++ b/server/services/StripeService.js
@@ -5,9 +5,11 @@ const StripeUserRepository = require('../repositories/StripeUserRepository');
 const StripeTransactionRepository = require('../repositories/StripeTransactionRepository');
 
 
+const STRIPE_WEBHOOK_SECRET = process.env.STRIPE_WEBHOOK_SECRET
 const stripe = new Stripe(process.env.STRIPE_SECRET_KEY);
 
 class StripeService {
+
     constructor(userId){
         this.userId = userId // user tied to Greenstand
 
@@ -62,9 +64,22 @@ class StripeService {
         return checkoutSession.url
     }
     
-    async verifyCheckout(webhookData) {
-        const transactionId = webhookData.object.client_reference_id
-        await this.__updateTransaction(transactionId, 'PAID')
+    async verifyCheckout(webhookData, dataSignature) {
+        const event = stripe.webhooks.constructEvent(
+            webhookData,
+            dataSignature,
+            STRIPE_WEBHOOK_SECRET,
+        );
+
+        const eventType = event.type;
+        const transactionId = event.data.object.client_reference_id;
+
+        if (eventType === 'checkout.session.completed') {
+            await this.__updateTransaction(transactionId, 'PAID');
+        } else {
+            await this.__updateTransaction(transactionId, 'FAILED');
+        }
+
     }
 }
 

--- a/server/services/StripeService.js
+++ b/server/services/StripeService.js
@@ -1,0 +1,71 @@
+const Stripe = require("stripe");
+const Session = require('../infra/database/Session');
+
+const StripeUserRepository = require('../repositories/StripeUserRepository');
+const StripeTransactionRepository = require('../repositories/StripeTransactionRepository');
+
+
+const stripe = new Stripe(process.env.STRIPE_SECRET_KEY);
+
+class StripeService {
+    constructor(userId){
+        this.userId = userId // user tied to Greenstand
+
+        this._session = new Session();
+        this._stripeUserRepo = new StripeUserRepository(this._session);
+        this._stripeTransactionRepo = new StripeTransactionRepository(this._session)
+    }
+
+    #getOrCreateStripeUser = async () => {
+        let stripeUser = await this._stripeUserRepo.getByUserId(this.userId)
+        if (!stripeUser){
+            // In reality, we should be getting this from the user record
+            const userInfo = {name: 'Test User', email: 'testuser@test.com'}
+            const customer = await stripe.customers.create(userInfo);
+
+            const stripeCustomerId = customer["id"]
+            stripeUser = await this._stripeUserRepo.create(this.userId, stripeCustomerId)
+        }
+
+        return stripeUser
+    }
+
+    #createTransaction = async (stripeUserId) => {
+        return await this._stripeTransactionRepo.create(stripeUserId)
+    }
+
+    #updateTransaction = async (transactionId, status) => {
+        return await this._stripeTransactionRepo.updateStatus(transactionId, status)
+    }
+
+    createCheckout = async (metaInfo={}) => {
+        const stripeUser = await this.#getOrCreateStripeUser()
+        const stripeTransaction = await this.#createTransaction(stripeUser.id)
+
+        const checkoutSession = await stripe.checkout.sessions.create({
+            mode: 'payment',
+            customer: stripeUser.stripe_customer_id,
+            client_reference_id: stripeTransaction.id,
+            metadata: metaInfo,
+            success_url: 'http://localhost:3000/home',
+            cancel_url: 'http://localhost:3000/home',
+            line_items: [
+                {   
+                    quantity: 1,
+                    price_data: { currency: 'usd', unit_amount: 100, product_data: {name: 'token'} },   
+                },
+            ],
+        });
+
+        console.log(checkoutSession)
+
+        return checkoutSession["url"]
+    }
+    
+    verifyCheckout = async (webhookData) => {
+        const transactionId = webhookData["object"]["client_reference_id"]
+        await this.#updateTransaction(transactionId, 'PAID')
+    }
+}
+
+module.exports = StripeService

--- a/server/services/StripeService.js
+++ b/server/services/StripeService.js
@@ -4,8 +4,6 @@ const Session = require('../infra/database/Session');
 const StripeUserRepository = require('../repositories/StripeUserRepository');
 const StripeTransactionRepository = require('../repositories/StripeTransactionRepository');
 
-
-const STRIPE_WEBHOOK_SECRET = process.env.STRIPE_WEBHOOK_SECRET
 const stripe = new Stripe(process.env.STRIPE_SECRET_KEY);
 
 class StripeService {
@@ -68,7 +66,7 @@ class StripeService {
         const event = stripe.webhooks.constructEvent(
             webhookData,
             dataSignature,
-            STRIPE_WEBHOOK_SECRET,
+            process.env.STRIPE_WEBHOOK_SECRET,
         );
 
         const eventType = event.type;


### PR DESCRIPTION
## Flow

1. Get Stripe hosted Checkout page. In reality this will get triggered with some button click or something: 
  
<img height="95" alt="Screenshot 2026-05-03 at 1 23 41 PM" src="https://github.com/user-attachments/assets/ec4cd8a8-eeb1-4160-9f32-665f5354bf72" />


2. User will get redirect to the Stripe-hosted user page:

<img height="200" alt="Screenshot 2026-05-03 at 1 24 38 PM" src="https://github.com/user-attachments/assets/9165234b-56c9-4013-9ffa-96b4d1155a09" />


3. The user fills out the information, creates a payment. This is how it looks like on Stripe's side
<img height="150" alt="Screenshot 2026-05-03 at 1 26 26 PM" src="https://github.com/user-attachments/assets/763ec0ce-a65c-425c-86e5-013617d5e375" />


4. Once the payment is processed, it will call the webhook API. ~~This part of the flow, I have not tested yet.~~
EDIT[5/17] I have tested this with the stripe CLI, it works on my end now :)

## DB Thingz
These tables will be stand alone so that they can be scaled up. 
If we need to connect to a new feature (in this case, the token transfer), we can create a table to connect/dump feature-specific meta info

### stripe_user
- id (primary key, int)
- user_id (int, indexed)
   - Not OnetoOne on purpose in the case users want to save many payment info in the future. 
- stripe_customer_id (string, indexed) 
    - Sripe ref so they can save customer + customer's user info on their side.
    - Eventually we can maybe reuse the payment info instead of user going to checkout each time. 
- Created_at (datefield, auto now)
- Updated_at (datefield, auto now)
- deleted_at (datefiled, nullable)

<img height="205" alt="Screenshot 2026-05-03 at 1 27 47 PM" src="https://github.com/user-attachments/assets/5888c48b-9190-4607-8c65-9419e3337243" />

### stripe_transaction
This is basically the reference on our side of the payment.
- id (uuid, primary_key)
- stripe_user_id (Reference to stripe_userTable)
- Status (enum): 
   - PENDING, FAILED, CANCELLED, PAID
- Created_at (datefield, auto now)
- Updated_at (datefield, auto now)

<img height="100" alt="Screenshot 2026-05-03 at 1 28 02 PM" src="https://github.com/user-attachments/assets/650e3c39-e193-4b6a-86f1-9c83eacffd1c" />


## Blockers

1. Can someone help point me to the right user api repo? 😅 So all of these code can be moved there.
2. The previous code creates the [form in the FE](https://github.com/Greenstand/treetracker-wallet-app/pull/642).  But the [Stripe hosted checkout](https://stripe.com/payments/checkout?utm_campaign=AMER_US_en_Google_Search_Brand_Checkout_EXA-20550770147&utm_medium=cpc&utm_source=google&utm_content=673946537954&utm_term=stripe%20checkout&utm_matchtype=e&utm_adposition=&utm_device=c&gad_source=1&gad_campaignid=20550770147&gbraid=0AAAAADKNRO42o1EdFeVISoNrLoXQ3z-_z&gclid=CjwKCAjw5NvPBhAoEiwA_2egfkdIEmANBiKnftEL0sKyQVUTK7MDF6hK5rlj3iuXv1jp2F-Pi_gJRhoCjOUQAvD_BwE) does not need any FE component It is a great option if we want something fast and functional.  I would personally suggest going with this option because we're still in the earlier stage and it makes the possibility of security errors much smaller. 
    - It reduces the business logic we have to handle around 40% less.  Basically cuts almost all of the paymentmethod/paymentintent processing part of the original flow I discussed. 
    - It's mobile responsive
    - The caveat is it's not as configurable in terms of "Branding" 
   
