### PR TITLE
fix: use env var for Keycloak URL instead of hardcoding

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,4 +1,5 @@
 DATABASE_URL=postgresql://xxxxx:xxxxxxx@xxxxxxx.ondigitalocean.com:25060/database?ssl=true
 DATABASE_SCHEMA=wallet
+KEYCLOAK_URL=https://dev-k8s.treetracker.org/keycloak/realms/treetracker
 KEYCLOAK_ISSUER=
 KEYCLOAK_PUBLIC_KEY=

--- a/server/services/JWTService.js
+++ b/server/services/JWTService.js
@@ -16,11 +16,9 @@ class JWTService {
     const token = tokenArray[1];
     let walletId;
     if (token) {
-      // get the public key
-      // LOCAL DEV: in-cluster URL is unreachable; use the public dev Keycloak so
-      // local can fetch JWKS to verify dev-realm tokens (testuser1).
       const KEYCLOAK_URL =
-        'https://dev-k8s.treetracker.org/keycloak/realms/treetracker';
+        process.env.KEYCLOAK_URL ||
+        'http://keycloak-service.keycloak:8080/keycloak/realms/treetracker';
 
       const client = jwksClient({
         jwksUri: `${KEYCLOAK_URL}/protocol/openid-connect/certs`,


### PR DESCRIPTION
## Description

Use an environment variable for the Keycloak URL in JWTService.js instead of hardcoding it, so it works both inside K8s and for local development.

**Issue(s) addressed**
- Related to #538

**What kind of change(s) does this PR introduce?**

- [x] Enhancement
- [x] Bug fix
- [ ] Refactor

**Please check if the PR fulfils these requirements**

- [x] The commit message follows our guidelines
- [ ] Tests for the changes have been added (for bug fixes / features)
- [x] Docs have been added / updated (for bug fixes / features)

## Issue

**What is the current behavior?**

The Keycloak URL is hardcoded to the external endpoint (`https://dev-k8s.treetracker.org/keycloak/realms/treetracker`). This works for local development but bypasses the internal K8s network unnecessarily when running in-cluster.

**What is the new behavior?**

`JWTService.js` reads `KEYCLOAK_URL` from `process.env` with a fallback to the internal K8s service URL (`http://keycloak-service.keycloak:8080/keycloak/realms/treetracker`).

- **In K8s**: no env var needed defaults to the internal URL automatically
- **Local dev**: set `KEYCLOAK_URL=https://dev-k8s.treetracker.org/keycloak/realms/treetracker` in `.env`

Follows the same pattern as `MAP_CONFIG_API_URL` in `WalletService.js`. Updated `.env.example` accordingly.

## Breaking change

**Does this PR introduce a breaking change?**

No. The default fallback preserves the existing in-cluster behavior.

## Other useful information

This addresses @dadiorchen's review comment on #538 about using an env var so the internal K8s domain works in-cluster (as @Kpoke suggested) while still allowing local dev to use the external URL.