### PR TITLE
fix: replace non-existent knex.query() with knex.raw() in QueueService

### DIFF
--- a/server/services/QueueService.js
+++ b/server/services/QueueService.js
@@ -9,20 +9,16 @@ class QueueService {
    */
   static async sendWalletCreationNotification(wallet) {
     try {
-      const text = `INSERT into queue.message(channel, data) values ($1, $2) RETURNING *`;
-      const values = [
-        'wallet_created',
-        {
-          walletId: wallet.id,
-          userId: wallet.userId,
-          createdAt: wallet.createdAt,
-        },
-      ];
-
-      knex.query(text, values, (err, res) => {
-        if (err) throw Error(`insertion error: ${err}`);
-        log.debug(`postgres message dispatch success: ${res}`);
+      const data = JSON.stringify({
+        walletId: wallet.id,
+        userId: wallet.userId,
+        createdAt: wallet.createdAt,
       });
+
+      await knex.raw(
+        'INSERT INTO queue.message(channel, data) VALUES (?, ?) RETURNING *',
+        ['wallet_created', data],
+      );
       log.debug(
         `Wallet creation notification sent for wallet ID: ${wallet.id}`,
       );

--- a/server/services/QueueService.spec.js
+++ b/server/services/QueueService.spec.js
@@ -5,11 +5,11 @@ const knex = require('../infra/database/knex');
 const QueueService = require('./QueueService');
 
 describe('QueueService', () => {
-  let publishStub;
+  let knexRawStub;
   let logErrorStub;
 
   beforeEach(() => {
-    // publishStub = sinon.stub(queue, 'publish');
+    knexRawStub = sinon.stub(knex, 'raw').resolves();
     logErrorStub = sinon.stub(log, 'error');
   });
 
@@ -27,20 +27,21 @@ describe('QueueService', () => {
 
       await QueueService.sendWalletCreationNotification(wallet);
 
-      expect(publishStub.calledOnce).to.be.true;
-      expect(publishStub.firstCall.args[0]).to.deep.equal({
-        pgClient: knex,
-        channel: 'wallet_created',
-        data: {
-          walletId: 1,
-          userId: 42,
-          createdAt: '2025-04-29T00:00:00Z',
-        },
+      expect(knexRawStub.calledOnce).to.be.true;
+      expect(knexRawStub.firstCall.args[0]).to.equal(
+        'INSERT INTO queue.message(channel, data) VALUES (?, ?) RETURNING *',
+      );
+      expect(knexRawStub.firstCall.args[1][0]).to.equal('wallet_created');
+      const payload = JSON.parse(knexRawStub.firstCall.args[1][1]);
+      expect(payload).to.deep.equal({
+        walletId: 1,
+        userId: 42,
+        createdAt: '2025-04-29T00:00:00Z',
       });
     });
 
     it('should not throw error if publish fails', async () => {
-      publishStub.throws(new Error('publish failed'));
+      knexRawStub.rejects(new Error('publish failed'));
 
       const wallet = {
         id: 2,
@@ -56,7 +57,6 @@ describe('QueueService', () => {
       }
 
       expect(errorCaught).to.be.false;
-      expect(publishStub.calledOnce).to.be.true;
       expect(logErrorStub.calledOnce).to.be.true;
       expect(logErrorStub.firstCall.args[0]).to.equal(
         'Failed to publish wallet creation message:',


### PR DESCRIPTION
## Description

Fix QueueService to use `knex.raw()` instead of non-existent `knex.query()`, and add unit tests.

**Issue(s) addressed**
-  fixes broken QueueService.

**What kind of change(s) does this PR introduce?**

- [ ] Enhancement
- [x] Bug fix
- [ ] Refactor

**Please check if the PR fulfils these requirements**

- [x] The commit message follows our guidelines
- [x] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)

## Issue

**What is the current behavior?**

`QueueService.sendWalletCreationNotification()` calls `knex.query()` which does not exist in Knex.js that method belongs to the lower-level `pg` (node-postgres) driver. Every wallet creation notification silently fails with `TypeError: knex.query is not a function`. The error is caught internally so wallet creation still succeeds, but no notification is ever published to the queue.

**What is the new behavior?**

- Uses `knex.raw()` with `?` parameterized placeholders (Knex style) instead of `$1, $2` (pg style)
- Adds `JSON.stringify()` for the data payload since `knex.raw()` does not auto-serialize objects
- Uses `await` instead of a callback . Knex returns Promises, not callbacks
- Wallet creation notifications are now correctly inserted into `queue.message`

Two unit tests verified:
1. correct SQL, channel name, and JSON payload
2. Error handling. verifies errors are caught and logged, not thrown

## Breaking change

**Does this PR introduce a breaking change?**

No. This fixes a silently broken feature. No API changes.
