### PR TITLE
fix: rewrite JWTService tests for async Keycloak verification

### DIFF
--- a/server/services/JWTService.spec.js
+++ b/server/services/JWTService.spec.js
@@ -1,52 +1,79 @@
 const sinon = require('sinon');
-const { expect } = require('chai');
+const chai = require('chai');
+const chaiAsPromised = require('chai-as-promised');
 const JWTTools = require('jsonwebtoken');
+const jwksClient = require('jwks-rsa');
 const JWTService = require('./JWTService');
+
+chai.use(chaiAsPromised);
+const { expect } = chai;
 
 describe('JWTService', () => {
   describe('verify', () => {
     afterEach(() => {
       sinon.restore();
     });
-    it('should error out if authorization is empty', () => {
-      expect(() => JWTService.verify()).to.throw(
+
+    it('should error out if authorization is empty', async () => {
+      await expect(JWTService.verify()).to.be.rejectedWith(
         'ERROR: Authentication, no token supplied for protected path',
       );
     });
 
-    it('invalid bearer token', () => {
-      expect(() => JWTService.verify('this is the token')).to.throw(
+    it('invalid bearer token', async () => {
+      await expect(
+        JWTService.verify('this is the token'),
+      ).to.be.rejectedWith(
         'ERROR: Authentication, invalid token received',
       );
     });
 
-    it('token not verified successfully', () => {
-      expect(() => JWTService.verify('Bearer invalid_token')).to.throw(
+    it('token not verified successfully', async () => {
+      sinon
+        .stub(jwksClient.JwksClient.prototype, 'getSigningKey')
+        .resolves({ getPublicKey: () => 'fake-public-key' });
+      sinon
+        .stub(JWTTools, 'verify')
+        .callsFake((token, publicKey, options, callback) => {
+          callback(new Error('invalid signature'), undefined);
+        });
+
+      await expect(
+        JWTService.verify('Bearer invalid_token'),
+      ).to.be.rejectedWith(
         'ERROR: Authentication, token not verified',
       );
     });
 
-    it('token verified but has no sub', () => {
+    it('token verified but has no sub', async () => {
+      sinon
+        .stub(jwksClient.JwksClient.prototype, 'getSigningKey')
+        .resolves({ getPublicKey: () => 'fake-public-key' });
       sinon
         .stub(JWTTools, 'verify')
         .callsFake((token, publicKey, options, callback) => {
           callback(undefined, { id: 'userId' });
         });
 
-      expect(() => JWTService.verify('Bearer no_sub_token')).to.throw(
+      await expect(
+        JWTService.verify('Bearer no_sub_token'),
+      ).to.be.rejectedWith(
         'ERROR: Authentication, invalid token received',
       );
     });
 
-    it('token verified successfully', () => {
+    it('token verified successfully', async () => {
+      sinon
+        .stub(jwksClient.JwksClient.prototype, 'getSigningKey')
+        .resolves({ getPublicKey: () => 'fake-public-key' });
       sinon
         .stub(JWTTools, 'verify')
         .callsFake((token, publicKey, options, callback) => {
           callback(undefined, { sub: 'userId' });
         });
 
-      const result = JWTService.verify('Bearer no_sub_token');
-      expect(result).eql({ id: 'userId' });
+      const result = await JWTService.verify('Bearer valid_token');
+      expect(result).to.eql({ id: 'userId' });
     });
   });
 });


### PR DESCRIPTION
## Description

Rewrite JWTService tests to work with the new async Keycloak-based token verification.

**Issue(s) addressed**
-  fixes broken JWTService tests

**What kind of change(s) does this PR introduce?**

- [ ] Enhancement
- [x] Bug fix
- [ ] Refactor

**Please check if the PR fulfils these requirements**

- [x] The commit message follows our guidelines
- [x] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)

## Issue

**What is the current behavior?**

JWTService tests fail because `JWTService.verify()`  changed from synchronous (verifying tokens using a local public key from `process.env`) to asynchronous (fetching the public key from Keycloak via JWKS over the network).

The old tests use `expect(() => JWTService.verify()).to.throw()` which does not work with async functions. async functions return rejected Promises instead of throwing synchronously. All 5 JWTService tests fail.

**What is the new behavior?**

- Uses `chai-as-promised` (already in `package.json`, just not imported in this test file) for async rejection assertions: `await expect(promise).to.be.rejectedWith(...)`
- Stubs `jwksClient.JwksClient.prototype.getSigningKey` to return a fake public key, so tests don't make real HTTP calls to Keycloak
- Stubs `jsonwebtoken.verify` to control the callback behavior for each test scenario

5 tests covering:
1. No authorization header . rejects immediately
2. Invalid bearer token format. rejects immediately
3. Token signature not verified. rejects after JWKS fetch
4. Token verified but missing `sub` claim. rejects after decode
5. Token verified successfully .returns `{ id: userId }`

## Breaking change

**Does this PR introduce a breaking change?**

No. Test-only changes, no production code modified.

## Other useful information

No new dependencies added. `chai-as-promised` was already installed, it just wasn't imported in this specific test file.