### PR TITLE
fix: restrict registration gift to parent wallets

### DIFF
--- a/server/handlers/walletHandler/index.js
+++ b/server/handlers/walletHandler/index.js
@@ -166,25 +166,27 @@ const walletPost = async (req, res) => {
 
   await QueueService.sendWalletCreationNotification(returnedWallet);
 
-  // Is this the current user's FIRST wallet? Count the wallets the user owns/manages
-  // (their account/parent wallet + any managed sub-wallets); first wallet => count === 1.
-  const parentWalletId = wallet_id || returnedWallet.id;
   let isFirstWallet = false;
-  try {
-    const { count } = await walletService.getAllWallets(
-      parentWalletId,
-      { limit: 1, offset: 0 },
-      undefined,
-      'created_at',
-      'desc',
-      undefined,
-      undefined,
-      false, // skip per-wallet token counting (we only need the count)
-      true, // getWalletCount
-    );
-    isFirstWallet = Number(count) === 1;
-  } catch (err) {
-    log.error(`Failed to count wallets for ${parentWalletId}: ${err.message}`);
+  if (!wallet_id) {
+    // Count the wallets the new user owns/manages; first wallet => count === 1.
+    try {
+      const { count } = await walletService.getAllWallets(
+        returnedWallet.id,
+        { limit: 1, offset: 0 },
+        undefined,
+        'created_at',
+        'desc',
+        undefined,
+        undefined,
+        false, // skip per-wallet token counting (we only need the count)
+        true, // getWalletCount
+      );
+      isFirstWallet = Number(count) === 1;
+    } catch (err) {
+      log.error(
+        `Failed to count wallets for ${returnedWallet.id}: ${err.message}`,
+      );
+    }
   }
 
   // System gift: on the user's first wallet, award REGISTER_REWARD_TOKEN_COUNT tokens


### PR DESCRIPTION
## Description
Restricts the first-wallet count used by the registration gift flow to parent wallet creation. Managed wallet creation no longer runs the count or qualifies for the registration gift.

Follow-up to the review on #543.

**Issue(s) addressed**
- Resolves the parent-wallet guard requested in #543

**What kind of change(s) does this PR introduce?**
- [ ] Enhancement
- [x] Bug fix
- [ ] Refactor

**Please check if the PR fulfils these requirements**
- [x] The commit message follows our guidelines
- [x] Existing unit tests pass
- [ ] Docs have been added / updated (not applicable)

## Issue

**What is the current behavior?**
The first-wallet count runs for both parent and managed wallet creation, allowing managed wallets to enter the registration gift decision.

**What is the new behavior?**
The first-wallet count only runs when creating a parent wallet (`!wallet_id`).

## Breaking change

**Does this PR introduce a breaking change?**
No.

## Other useful information
`npm run test-unit-ci`: 234 passing.