### PR TITLE
Add wallet scope filtering for wallet listings and transfers

### DIFF
--- a/server/handlers/walletHandler/index.js
+++ b/server/handlers/walletHandler/index.js
@@ -29,6 +29,7 @@ const walletGet = async (req, res) => {
     order,
     created_at_start_date,
     created_at_end_date,
+    scope,
   } = validatedQuery;
 
   const { wallet_id } = req;
@@ -44,6 +45,7 @@ const walletGet = async (req, res) => {
     order,
     created_at_start_date,
     created_at_end_date,
+    scope,
   );
 
   res.status(200).json({

--- a/server/handlers/walletHandler/schemas.js
+++ b/server/handlers/walletHandler/schemas.js
@@ -20,6 +20,7 @@ const walletGetQuerySchema = Joi.object({
   order: Joi.string().valid('asc', 'desc').default('desc'),
   created_at_start_date: Joi.date().iso(),
   created_at_end_date: Joi.date().iso(),
+  scope: Joi.string().valid('all', 'child', 'managed'),
 });
 
 const walletIdParamSchema = Joi.object({

--- a/server/models/Transfer.js
+++ b/server/models/Transfer.js
@@ -71,15 +71,30 @@ class Transfer {
     order,
     prioritize_pending_receiver_action_for_wallet_id,
   }) {
+    const { wallets: visibleWallets } = await this._wallet.getAllWallets(
+      walletLoginId,
+      undefined,
+      undefined,
+      'created_at',
+      'desc',
+      undefined,
+      undefined,
+      'all',
+      false,
+    );
+    const visibleWalletIds = Array.from(
+      new Set([walletLoginId, ...visibleWallets.map((wallet) => wallet.id)]),
+    );
+
     const filter = {
       and: [],
     };
     filter.and.push({
-      or: [
-        { source_wallet_id: walletLoginId },
-        { destination_wallet_id: walletLoginId },
-        { originator_wallet_id: walletLoginId },
-      ],
+      or: visibleWalletIds.flatMap((visibleWalletId) => [
+        { source_wallet_id: visibleWalletId },
+        { destination_wallet_id: visibleWalletId },
+        { originator_wallet_id: visibleWalletId },
+      ]),
     });
     if (state) {
       filter.and.push({ state });

--- a/server/models/Wallet.js
+++ b/server/models/Wallet.js
@@ -161,6 +161,7 @@ class Wallet {
     order,
     created_at_start_date,
     created_at_end_date,
+    scope,
     getCount,
   ) {
     return this._walletRepository.getAllWallets(
@@ -171,6 +172,7 @@ class Wallet {
       order,
       created_at_start_date,
       created_at_end_date,
+      scope,
       getCount,
     );
   }

--- a/server/models/Wallet.spec.js
+++ b/server/models/Wallet.spec.js
@@ -151,6 +151,7 @@ describe('Wallet Model', () => {
       'asc',
       undefined,
       undefined,
+      undefined,
       false,
     );
 
@@ -163,6 +164,7 @@ describe('Wallet Model', () => {
       wallet,
       'created_at',
       'asc',
+      undefined,
       undefined,
       undefined,
       false,

--- a/server/repositories/WalletRepository.js
+++ b/server/repositories/WalletRepository.js
@@ -147,10 +147,6 @@ class WalletRepository extends BaseRepository {
         .table('wallet')
         .where('id', id);
 
-      if (name) {
-        selfQuery.where('name', 'ilike', `%${name}%`);
-      }
-
       query = selfQuery.union([
         withNameFilter(childWallets),
         withNameFilter(directManagedWallets),

--- a/server/repositories/WalletRepository.js
+++ b/server/repositories/WalletRepository.js
@@ -62,15 +62,12 @@ class WalletRepository extends BaseRepository {
     order,
     created_at_start_date,
     created_at_end_date,
+    scope,
     getCount,
   ) {
-    let query = this._session
-      .getDB()
-      .select('id', 'name', 'about', 'logo_url', 'created_at')
-      .table('wallet')
-      .where('id', id);
+    const effectiveScope = scope || 'all';
 
-    let union1 = this._session
+    const childWallets = this._session
       .getDB()
       .select(
         'wallet.id',
@@ -87,9 +84,30 @@ class WalletRepository extends BaseRepository {
           TrustRelationshipEnums.ENTITY_TRUST_REQUEST_TYPE.manage,
         'wallet_trust.state':
           TrustRelationshipEnums.ENTITY_TRUST_STATE_TYPE.trusted,
-      });
+      })
+      .whereNull('wallet.password');
 
-    let union2 = this._session
+    const directManagedWallets = this._session
+      .getDB()
+      .select(
+        'wallet.id',
+        'wallet.name',
+        'wallet.about',
+        'wallet.logo_url',
+        'wallet.created_at',
+      )
+      .table('wallet_trust')
+      .join('wallet', 'wallet_trust.target_wallet_id', '=', 'wallet.id')
+      .where({
+        'wallet_trust.actor_wallet_id': id,
+        'wallet_trust.request_type':
+          TrustRelationshipEnums.ENTITY_TRUST_REQUEST_TYPE.manage,
+        'wallet_trust.state':
+          TrustRelationshipEnums.ENTITY_TRUST_STATE_TYPE.trusted,
+      })
+      .whereNotNull('wallet.password');
+
+    const yieldManagedWallets = this._session
       .getDB()
       .select(
         'wallet.id',
@@ -108,14 +126,43 @@ class WalletRepository extends BaseRepository {
           TrustRelationshipEnums.ENTITY_TRUST_STATE_TYPE.trusted,
       });
 
-    if (name) {
-      union1 = union1.where('name', 'ilike', `%${name}%`);
-      union2 = union2.where('name', 'ilike', `%${name}%`);
+    const withNameFilter = (queryBuilder) => {
+      if (!name) {
+        return queryBuilder;
+      }
+      return queryBuilder.where('wallet.name', 'ilike', `%${name}%`);
+    };
+
+    let query;
+    if (effectiveScope === 'child') {
+      query = withNameFilter(childWallets);
+    } else if (effectiveScope === 'managed') {
+      query = withNameFilter(directManagedWallets).union(
+        withNameFilter(yieldManagedWallets),
+      );
+    } else {
+      const selfQuery = this._session
+        .getDB()
+        .select('id', 'name', 'about', 'logo_url', 'created_at')
+        .table('wallet')
+        .where('id', id);
+
+      if (name) {
+        selfQuery.where('name', 'ilike', `%${name}%`);
+      }
+
+      query = selfQuery.union([
+        withNameFilter(childWallets),
+        withNameFilter(directManagedWallets),
+        withNameFilter(yieldManagedWallets),
+      ]);
     }
 
-    query = query.union(union1, union2).orderBy(sort_by, order);
-
-    query = this._session.getDB().select('*').from(query.as('t'));
+    query = this._session
+      .getDB()
+      .select('*')
+      .from(query.as('t'))
+      .orderBy(sort_by, order);
 
     if (created_at_start_date) {
       query = query.whereRaw(`cast("created_at" as date) >= ?`, [

--- a/server/repositories/WalletRepository.spec.js
+++ b/server/repositories/WalletRepository.spec.js
@@ -105,6 +105,7 @@ describe('WalletRepository', () => {
       'desc',
       undefined,
       undefined,
+      undefined,
       true,
     );
     expect(entity).to.eql({ wallets: [{ id: 1 }], count: 1 });

--- a/server/services/WalletService.js
+++ b/server/services/WalletService.js
@@ -171,6 +171,7 @@ class WalletService {
     order,
     created_at_start_date,
     created_at_end_date,
+    scope,
     getTokenCount = true,
     getWalletCount = true,
   ) {
@@ -184,6 +185,7 @@ class WalletService {
         order,
         created_at_start_date,
         created_at_end_date,
+        scope,
         getWalletCount,
       );
       return {
@@ -205,6 +207,7 @@ class WalletService {
       order,
       created_at_start_date,
       created_at_end_date,
+      scope,
       getWalletCount,
     );
   }

--- a/server/services/WalletService.spec.js
+++ b/server/services/WalletService.spec.js
@@ -245,9 +245,11 @@ describe('WalletService', () => {
         'asc',
         undefined,
         undefined,
+        undefined,
         false,
       );
-      expect(getAllWalletsStub).calledOnceWithExactly(
+      expect(
+        getAllWalletsStub.calledOnceWithExactly(
         id,
         limitOptions,
         'name',
@@ -255,9 +257,10 @@ describe('WalletService', () => {
         'asc',
         undefined,
         undefined,
+        undefined,
         true,
-      );
-      // ).eql(true);
+        ),
+      ).eql(true);
       expect(allWallets).eql({ wallets: result, count });
     });
 


### PR DESCRIPTION
## Description
Add scoped wallet listing support and update transfer visibility logic so wallet queries can distinguish between child wallets, managed wallets, and the full related wallet scope.


**What kind of change(s) does this PR introduce?**

- [x] Enhancement
- [x] Bug fix
- [ ] Refactor

**Please check if the PR fulfils these requirements**

- [x] The commit message follows our guidelines
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)

## Issue

**What is the current behavior?**
Wallet listing behavior does not distinguish between child wallets created under the main wallet and other trust-managed wallets. As a result, frontend wallet lists can include unrelated managed entries. Also, transfer visibility needed explicit support for the broader related-wallet scope after introducing scoped wallet queries.

**What is the new behavior?**
The wallet listing endpoint now supports an optional `scope` query parameter with `all`, `child`, and `managed` values.
- `child` returns wallets created under the main wallet
- `managed` returns trust-managed related wallets
- omitting `scope` keeps the previous broader behavior

Transfer visibility now uses the full related wallet scope so My Transfers still includes activity across the expected managed and trusted wallet flows.

## Breaking change

**Does this PR introduce a breaking change?**
No. Existing behavior is preserved when the new `scope` parameter is not provided.

## Other useful information
This PR is intended to support wallet admin client filtering and transfer visibility requirements.