### PR TITLE
feat(wallet-api): send token by email via JWT action token (#457)

### DIFF
--- a/__tests__/actiontoken-expired.spec.js
+++ b/__tests__/actiontoken-expired.spec.js
@@ -1,0 +1,73 @@
+/*
+ * Integration test for issue send tokens via email: redeeming an expired action token is denied
+ * and no transfer happens
+ */
+require('dotenv').config();
+const request = require('supertest');
+const { expect } = require('chai');
+const chai = require('chai');
+const server = require('../server/app');
+const seed = require('./seed');
+const JWTService = require('../server/services/JWTService');
+
+chai.use(require('chai-uuid'));
+
+const { apiKey } = seed;
+
+describe('Redeem an expired action token', () => {
+  let bearerToken;
+  let bearerTokenB;
+  let expiredActionToken;
+
+  before(async () => {
+    await seed.clear();
+    await seed.seed();
+
+    {
+      const res = await request(server)
+        .post('/auth')
+        .set('treetracker-api-key', apiKey)
+        .send({ wallet: seed.wallet.name, password: seed.wallet.password });
+      expect(res).to.have.property('statusCode', 200);
+      bearerToken = res.body.token;
+    }
+
+    {
+      const res = await request(server)
+        .post('/auth')
+        .set('treetracker-api-key', apiKey)
+        .send({ wallet: seed.walletB.name, password: seed.walletB.password });
+      expect(res).to.have.property('statusCode', 200);
+      bearerTokenB = res.body.token;
+    }
+
+    expiredActionToken = JWTService.signActionToken(
+      {
+        sub: 'samwel@example.com',
+        sender_wallet_id: seed.wallet.id,
+        token_ids: [seed.token.id],
+      },
+      { expiresIn: '-1s' },
+    );
+  });
+
+  it(`${seed.walletB.name} is denied with 401 when redeeming an expired token`, async () => {
+    const res = await request(server)
+      .post('/action-tokens/redeem')
+      .set('treetracker-api-key', apiKey)
+      .set('Authorization', `Bearer ${bearerTokenB}`)
+      .send({ action_token: expiredActionToken });
+
+    expect(res).to.have.property('statusCode', 401);
+  });
+
+  it(`the token still belongs to ${seed.wallet.name}`, async () => {
+    const res = await request(server)
+      .get(`/tokens/${seed.token.id}`)
+      .set('treetracker-api-key', apiKey)
+      .set('Authorization', `Bearer ${bearerToken}`);
+
+    expect(res).to.have.property('statusCode', 200);
+    expect(res.body).to.have.property('id').eq(seed.token.id);
+  });
+});

--- a/__tests__/actiontoken-transfer.spec.js
+++ b/__tests__/actiontoken-transfer.spec.js
@@ -1,0 +1,88 @@
+/*
+ * Integration test for send tokens via email: a wallet owner issues an action token and a
+ * second wallet redeems it to receive the tokens.
+ */
+require('dotenv').config();
+const request = require('supertest');
+const { expect } = require('chai');
+const chai = require('chai');
+const server = require('../server/app');
+const seed = require('./seed');
+
+chai.use(require('chai-uuid'));
+
+const { apiKey } = seed;
+
+describe('Issue and redeem an action token', () => {
+  let bearerToken;
+  let bearerTokenB;
+  let actionToken;
+
+  before(async () => {
+    await seed.clear();
+    await seed.seed();
+
+    {
+      const res = await request(server)
+        .post('/auth')
+        .set('treetracker-api-key', apiKey)
+        .send({ wallet: seed.wallet.name, password: seed.wallet.password });
+      expect(res).to.have.property('statusCode', 200);
+      bearerToken = res.body.token;
+    }
+
+    {
+      const res = await request(server)
+        .post('/auth')
+        .set('treetracker-api-key', apiKey)
+        .send({ wallet: seed.walletB.name, password: seed.walletB.password });
+      expect(res).to.have.property('statusCode', 200);
+      bearerTokenB = res.body.token;
+    }
+  });
+
+  it(`${seed.wallet.name} issues an action token for its token`, async () => {
+    const res = await request(server)
+      .post('/action-tokens')
+      .set('treetracker-api-key', apiKey)
+      .set('Authorization', `Bearer ${bearerToken}`)
+      .send({ recipient_email: 'samwel@example.com', tokens: [seed.token.id] });
+
+    expect(res).to.have.property('statusCode', 201);
+    expect(res.body).to.have.property('action_token').that.match(/\S+/);
+    expect(res.body).to.have.property('token_count', 1);
+    expect(res.body).to.have.property('expires_at');
+    actionToken = res.body.action_token;
+  });
+
+  it(`${seed.walletB.name} redeems the action token and the transfer completes`, async () => {
+    const res = await request(server)
+      .post('/action-tokens/redeem')
+      .set('treetracker-api-key', apiKey)
+      .set('Authorization', `Bearer ${bearerTokenB}`)
+      .send({ action_token: actionToken });
+
+    expect(res).to.have.property('statusCode', 200);
+    expect(res.body).to.have.property('state', 'completed');
+    expect(res.body.parameters.tokens).to.include(seed.token.id);
+  });
+
+  it(`the token now belongs to ${seed.walletB.name}`, async () => {
+    const res = await request(server)
+      .get(`/tokens/${seed.token.id}`)
+      .set('treetracker-api-key', apiKey)
+      .set('Authorization', `Bearer ${bearerTokenB}`);
+
+    expect(res).to.have.property('statusCode', 200);
+    expect(res.body).to.have.property('id').eq(seed.token.id);
+  });
+
+  it(`the token no longer belongs to ${seed.wallet.name}`, async () => {
+    const res = await request(server)
+      .get(`/tokens/${seed.token.id}`)
+      .set('treetracker-api-key', apiKey)
+      .set('Authorization', `Bearer ${bearerToken}`);
+
+    expect(res).to.have.property('statusCode', 403);
+  });
+});

--- a/server/handlers/actionTokenHandler/index.js
+++ b/server/handlers/actionTokenHandler/index.js
@@ -1,0 +1,32 @@
+const ActionTokenService = require('../../services/ActionTokenService');
+const {
+  actionTokenGenerateSchema,
+  actionTokenRedeemSchema,
+} = require('./schemas');
+
+const actionTokenGenerate = async (req, res) => {
+  const validatedBody = await actionTokenGenerateSchema.validateAsync(
+    req.body,
+    { abortEarly: false },
+  );
+  const { wallet_id } = req;
+
+  const actionTokenService = new ActionTokenService();
+  const result = await actionTokenService.generate(validatedBody, wallet_id);
+
+  res.status(201).json(result);
+};
+
+const actionTokenRedeem = async (req, res) => {
+  const validatedBody = await actionTokenRedeemSchema.validateAsync(req.body, {
+    abortEarly: false,
+  });
+  const { wallet_id } = req;
+
+  const actionTokenService = new ActionTokenService();
+  const result = await actionTokenService.redeem(validatedBody, wallet_id);
+
+  res.status(200).json(result);
+};
+
+module.exports = { actionTokenGenerate, actionTokenRedeem };

--- a/server/handlers/actionTokenHandler/schemas.js
+++ b/server/handlers/actionTokenHandler/schemas.js
@@ -1,0 +1,27 @@
+const Joi = require('joi');
+
+// Issue: either explicit token ids or a bundle size, plus the recipient email.
+// Mirrors the tokens|bundle shape of the transfer POST schema.
+const actionTokenGenerateSchema = Joi.alternatives().conditional(
+  Joi.object({
+    tokens: Joi.any().required(),
+  }).unknown(),
+  {
+    then: Joi.object({
+      recipient_email: Joi.string().email().required(),
+      tokens: Joi.array().items(Joi.string().uuid()).required().unique(),
+    }),
+    otherwise: Joi.object({
+      recipient_email: Joi.string().email().required(),
+      bundle: Joi.object({
+        bundle_size: Joi.number().integer().min(1).max(10000).required(),
+      }).required(),
+    }),
+  },
+);
+
+const actionTokenRedeemSchema = Joi.object({
+  action_token: Joi.string().required(),
+});
+
+module.exports = { actionTokenGenerateSchema, actionTokenRedeemSchema };

--- a/server/models/Transfer.js
+++ b/server/models/Transfer.js
@@ -125,8 +125,7 @@ class Transfer {
     };
 
     if (prioritize_pending_receiver_action_for_wallet_id !== undefined) {
-      limitOptions.prioritize_pending_receiver_action_for_wallet_id =
-        prioritize_pending_receiver_action_for_wallet_id;
+      limitOptions.prioritize_pending_receiver_action_for_wallet_id = prioritize_pending_receiver_action_for_wallet_id;
     }
 
     return this.getByFilter(filter, limitOptions);
@@ -254,6 +253,53 @@ class Transfer {
     }
     // TODO
     return expect.fail();
+  }
+
+  /*
+   *  Complete a transfer authorized by a redeemed action token
+   *  The signed token replaces trust/control checks 
+   *  Tokens are validated up front (all-or-nothing)
+   */ 
+  async transferActionToken(originatorWalletId, sender, receiver, tokens) {
+    tokens.forEach((token) => {
+      if (!Token.belongsTo(token, sender.id)) {
+        throw new HttpError(
+          409,
+          `The token ${token.id} is no longer owned by the sender wallet`,
+        );
+      }
+      if (!Token.beAbleToTransfer(token)) {
+        throw new HttpError(409, `The token ${token.id} cannot be transferred`);
+      }
+      if (token.claim) {
+        throw new HttpError(
+          409,
+          `The token ${token.id} is claimed, cannot be transferred`,
+        );
+      }
+    });
+
+    const transfer = await this.create({
+      originator_wallet_id: originatorWalletId,
+      source_wallet_id: sender.id,
+      destination_wallet_id: receiver.id,
+      state: TransferEnums.STATE.completed,
+      parameters: {
+        tokens: tokens.map((token) => token.id),
+      },
+      claim: false,
+    });
+
+    await this._token.completeTransfer(
+      tokens,
+      {
+        ...transfer,
+        source_wallet_id: sender.id,
+        destination_wallet_id: receiver.id,
+      },
+      false,
+    );
+    return transfer;
   }
 
   async transferBundle(

--- a/server/routes/actionTokenRouter.js
+++ b/server/routes/actionTokenRouter.js
@@ -1,0 +1,19 @@
+const express = require('express');
+
+const router = express.Router();
+const routerWrapper = express.Router();
+const {
+  handlerWrapper,
+  verifyJWTHandler,
+  apiKeyHandler,
+} = require('../utils/utils');
+const {
+  actionTokenGenerate,
+  actionTokenRedeem,
+} = require('../handlers/actionTokenHandler');
+
+router.post('/', handlerWrapper(actionTokenGenerate));
+router.post('/redeem', handlerWrapper(actionTokenRedeem));
+
+routerWrapper.use('/action-tokens', apiKeyHandler, verifyJWTHandler, router);
+module.exports = routerWrapper;

--- a/server/routes/index.js
+++ b/server/routes/index.js
@@ -5,4 +5,5 @@ module.exports = [
   require('./trustRouter'),
   require('./walletRouter'),
   require('./eventRouter'),
+  require('./actionTokenRouter'),
 ];

--- a/server/services/ActionTokenService.js
+++ b/server/services/ActionTokenService.js
@@ -1,0 +1,63 @@
+/**
+ * Action tokens for "send token by email": a stateless, signed,
+ * expiring token encoding an intention to transfer tokens to a future account
+*/
+const JWTService = require('./JWTService');
+const HttpError = require('../utils/HttpError');
+const TokenService = require('./TokenService');
+const TransferService = require('./TransferService');
+
+class ActionTokenService {
+  constructor() {
+    this._tokenService = new TokenService();
+    this._transferService = new TransferService();
+  }
+
+  async generate({ recipient_email, tokens, bundle }, walletLoginId) {
+    let tokenIds;
+
+    if (tokens) {
+      const resolved = await Promise.all(
+        tokens.map((id) => this._tokenService.getById({ id, walletLoginId })),
+      );
+      tokenIds = resolved.map((token) => token.id);
+    } else {
+      const resolved = await this._tokenService.getTokens({
+        limit: bundle.bundle_size,
+        offset: 0,
+        walletLoginId,
+      });
+      if (resolved.length < bundle.bundle_size) {
+        throw new HttpError(
+          409,
+          `Wallet does not have ${bundle.bundle_size} tokens available`,
+        );
+      }
+      tokenIds = resolved.map((token) => token.id);
+    }
+
+    const actionToken = JWTService.signActionToken({
+      sub: recipient_email,
+      sender_wallet_id: walletLoginId,
+      token_ids: tokenIds,
+    });
+
+    const { exp } = JWTService.verifyActionToken(actionToken);
+    return {
+      action_token: actionToken,
+      expires_at: new Date(exp * 1000).toISOString(),
+      token_count: tokenIds.length,
+    };
+  }
+
+  async redeem({ action_token }, walletLoginId) {
+    const payload = JWTService.verifyActionToken(action_token);
+    return this._transferService.redeemActionToken({
+      senderWalletId: payload.sender_wallet_id,
+      receiverWalletId: walletLoginId,
+      tokenIds: payload.token_ids,
+    });
+  }
+}
+
+module.exports = ActionTokenService;

--- a/server/services/JWTService.js
+++ b/server/services/JWTService.js
@@ -22,6 +22,9 @@ const verifyOptions = {
   algorithms: ['RS256'],
 };
 
+const ACTION_TOKEN_TYPE = 'send-token';
+const ACTION_TOKEN_TTL = process.env.ACTION_TOKEN_TTL || '7d';
+
 class JWTService {
   static sign(payload) {
     return JWTTools.sign(payload, privateKEY, signingOptions);
@@ -56,6 +59,34 @@ class JWTService {
       throw new HttpError(401, 'ERROR: Authentication, token not verified');
     }
     return result;
+  }
+
+  static signActionToken(payload, options = {}) {
+    return JWTTools.sign({ ...payload, action: ACTION_TOKEN_TYPE }, privateKEY, {
+      ...signingOptions,
+      expiresIn: ACTION_TOKEN_TTL,
+      ...options,
+    });
+  }
+
+  static verifyActionToken(token) {
+    if (!token) {
+      throw new HttpError(401, 'ERROR: ActionToken, no token supplied');
+    }
+    let decoded;
+    try {
+      decoded = JWTTools.verify(token, publicKEY, verifyOptions);
+    } catch (err) {
+      log.debug(err);
+      if (err.name === 'TokenExpiredError') {
+        throw new HttpError(401, 'ERROR: ActionToken expired');
+      }
+      throw new HttpError(401, 'ERROR: ActionToken not verified');
+    }
+    if (decoded.action !== ACTION_TOKEN_TYPE) {
+      throw new HttpError(401, 'ERROR: ActionToken, invalid action type');
+    }
+    return decoded;
   }
 }
 

--- a/server/services/JWTService.spec.js
+++ b/server/services/JWTService.spec.js
@@ -9,4 +9,45 @@ describe('JWTService', () => {
     const result = JWTService.verify(`Bearer ${token}`);
     expect(result).property('id').eq(1);
   });
+
+  describe('action tokens', () => {
+    const payload = { sub: 'samwel@example.com', sender_wallet_id: 'w1' };
+
+    it('signs an action token that verifies with issuer and action claim', () => {
+      const token = JWTService.signActionToken(payload);
+      expect(token).match(/\S+/);
+      const result = JWTService.verifyActionToken(token);
+      expect(result).property('action').eq('send-token');
+      expect(result).property('iss').eq('greenstand');
+      expect(result).property('sub').eq('samwel@example.com');
+      expect(result).property('exp').to.be.a('number');
+    });
+
+    it('rejects an expired action token with 401', () => {
+      const token = JWTService.signActionToken(payload, { expiresIn: '-1s' });
+      expect(() => JWTService.verifyActionToken(token))
+        .to.throw()
+        .that.has.property('code', 401);
+    });
+
+    it('rejects a tampered/invalid signature with 401', () => {
+      const token = `${JWTService.signActionToken(payload)}tampered`;
+      expect(() => JWTService.verifyActionToken(token))
+        .to.throw()
+        .that.has.property('code', 401);
+    });
+
+    it('rejects a login token (missing action claim) with 401', () => {
+      const loginToken = JWTService.sign({ id: 1 });
+      expect(() => JWTService.verifyActionToken(loginToken))
+        .to.throw()
+        .that.has.property('code', 401);
+    });
+
+    it('rejects a missing token with 401', () => {
+      expect(() => JWTService.verifyActionToken())
+        .to.throw()
+        .that.has.property('code', 401);
+    });
+  });
 });

--- a/server/services/TransferService.js
+++ b/server/services/TransferService.js
@@ -446,6 +446,56 @@ class TransferService {
     }
   }
 
+
+   // Transfer the tokens promised by a redeemed action token 
+  async redeemActionToken({ senderWalletId, receiverWalletId, tokenIds }) {
+    try {
+      await this._session.beginTransaction();
+
+      const senderWallet = await this._walletService.getById(senderWalletId);
+      const receiverWallet =
+        await this._walletService.getById(receiverWalletId);
+
+      const tokenService = new TokenService();
+      const tokens = await Promise.all(
+        tokenIds.map((id) => tokenService.getById({ id }, true)),
+      );
+
+      const result = await this._transfer.transferActionToken(
+        receiverWallet.id,
+        senderWallet,
+        receiverWallet,
+        tokens,
+      );
+
+      const payload = {
+        walletSender: senderWallet.name,
+        walletReceiver: receiverWallet.name,
+        tokenTransferred: tokenIds,
+      };
+
+      // the log should show up on both sender and receiver
+      await this._eventService.logEvent({
+        wallet_id: senderWallet.id,
+        type: EventEnums.TRANSFER.transfer_completed,
+        payload,
+      });
+      await this._eventService.logEvent({
+        wallet_id: receiverWallet.id,
+        type: EventEnums.TRANSFER.transfer_completed,
+        payload,
+      });
+
+      await this._session.commitTransaction();
+      return result;
+    } catch (e) {
+      if (this._session.isTransactionInProgress()) {
+        await this._session.rollbackTransaction();
+      }
+      throw e;
+    }
+  }
+
   async getTransferById(transferId, walletLoginId) {
     const transfer = await this._transfer.getById({
       transferId,

--- a/server/services/TransferService.spec.js
+++ b/server/services/TransferService.spec.js
@@ -1006,4 +1006,76 @@ describe('TransferService', () => {
       ).eql(true);
     });
   });
+
+  describe('redeemActionToken', () => {
+    const senderWallet = { id: 'sender-id', name: 'walletA' };
+    const receiverWallet = { id: 'receiver-id', name: 'walletB' };
+    let getByIdWalletStub;
+    let getByIdTokenStub;
+    let logEventStub;
+
+    beforeEach(() => {
+      getByIdWalletStub = sinon.stub(WalletService.prototype, 'getById');
+      getByIdWalletStub.withArgs('sender-id').resolves(senderWallet);
+      getByIdWalletStub.withArgs('receiver-id').resolves(receiverWallet);
+      getByIdTokenStub = sinon.stub(TokenService.prototype, 'getById');
+      logEventStub = sinon.stub(EventService.prototype, 'logEvent').resolves();
+    });
+
+    it('completes the transfer and logs events for both wallets', async () => {
+      getByIdTokenStub.resolves({
+        id: 't1',
+        wallet_id: 'sender-id',
+        transfer_pending: false,
+        claim: false,
+      });
+      const completed = {
+        id: 'transfer-1',
+        state: TransferEnums.STATE.completed,
+      };
+      const transferStub = sinon
+        .stub(Transfer.prototype, 'transferActionToken')
+        .resolves(completed);
+
+      const result = await transferService.redeemActionToken({
+        senderWalletId: 'sender-id',
+        receiverWalletId: 'receiver-id',
+        tokenIds: ['t1'],
+      });
+
+      expect(result).eql(completed);
+      expect(transferStub.calledOnce).eql(true);
+      expect(transferStub.firstCall.args[0]).eql('receiver-id');
+      expect(transferStub.firstCall.args[1]).eql(senderWallet);
+      expect(transferStub.firstCall.args[2]).eql(receiverWallet);
+      expect(logEventStub.calledTwice).eql(true);
+      expect(commitTransactionStub.calledOnce).eql(true);
+      expect(rollbackTransactionStub.called).eql(false);
+    });
+
+    it('rejects with 409 and rolls back when a token no longer belongs to the sender', async () => {
+      getByIdTokenStub.resolves({
+        id: 't1',
+        wallet_id: 'someone-else',
+        transfer_pending: false,
+        claim: false,
+      });
+
+      let error;
+      try {
+        await transferService.redeemActionToken({
+          senderWalletId: 'sender-id',
+          receiverWalletId: 'receiver-id',
+          tokenIds: ['t1'],
+        });
+      } catch (e) {
+        error = e;
+      }
+
+      expect(error).to.have.property('code', 409);
+      expect(logEventStub.called).eql(false);
+      expect(commitTransactionStub.called).eql(false);
+      expect(rollbackTransactionStub.calledOnce).eql(true);
+    });
+  });
 });


### PR DESCRIPTION
## Description
Implements #457: send tokens to a future account holder via a signed, expiring JWT action token.

Two endpoints, both behind the existing api-key and JWT auth:
- `POST /action-tokens` : issue a token for `tokens: [ids]` or `bundle: { bundle_size }`
- `POST /action-tokens/redeem` : verify and execute the transfer

**Issue(s) addressed**
- Resolves #457

**What kind of change(s) does this PR introduce?**

- [x] Enhancement
- [ ] Bug fix
- [ ] Refactor

**Please check if the PR fulfils these requirements**

- [x] The commit message follows our guidelines
- [x] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)

## Issue

**What is the current behavior?**
Token transfers require both the sender and receiver wallets to already exist;
there is no way to send tokens to someone who has not registered yet.

**What is the new behavior?**
- Issue a signed action token (RS256, issuer `greenstand`, default 7-day TTL)
  describing the sender wallet and the token ids to transfer.
- Redeem it from any authenticated wallet: the signed token is the
  authorization, so the named tokens move sender to redeemer as a single,
  atomic `completed` transfer.
- Expired, tampered, wrong-issuer, or wrong-type tokens are denied `401`.
- If the sender no longer owns a listed token at redeem time, it fails `409`
  with no partial transfer (accepted-risk case; no escrow in v1).
- Integration tests cover the issue→redeem happy path and expiry denial.

## Breaking change

**Does this PR introduce a breaking change?**
No.

## Other useful information
Scope intentionally limited per the issue discussion:
- No escrow / pending-hold of tokens at issue time (owner keeps custody)
- Bearer model: possession of the token authorizes redemption; the recipient
  email (`sub`) is informational
- No email delivery, one-time-use, or revocation in this version

