### PR TITLE
feat(wallet-api): send token by email via keycloak JWT action token (#457)

### DIFF
--- a/__tests__/actiontoken-expired.spec.js
+++ b/__tests__/actiontoken-expired.spec.js
@@ -1,0 +1,52 @@
+/**
+ * Integration test: redeeming an expired action token is denied, no transfer
+*/
+require('dotenv').config();
+const request = require('supertest');
+const { expect } = require('chai');
+const chai = require('chai');
+const server = require('../server/app');
+const seed = require('./seed');
+const ActionTokenService = require('../server/services/ActionTokenService');
+
+chai.use(require('chai-uuid'));
+
+describe('Redeem an expired action token', () => {
+  let bearerToken;
+  let bearerTokenB;
+  let expiredActionToken;
+
+  before(async () => {
+    await seed.clear();
+    await seed.seed();
+    bearerToken = seed.wallet.keycloak_account_id;
+    bearerTokenB = seed.walletB.keycloak_account_id;
+
+    expiredActionToken = ActionTokenService.signActionToken(
+      {
+        sub: 'samwel@example.com',
+        sender_wallet_id: seed.wallet.id,
+        token_ids: [seed.token.id],
+      },
+      { expiresIn: '-1s' },
+    );
+  });
+
+  it(`${seed.walletB.name} is denied with 401 when redeeming an expired token`, async () => {
+    const res = await request(server)
+      .post('/action-tokens/redeem')
+      .set('Authorization', `Bearer ${bearerTokenB}`)
+      .send({ action_token: expiredActionToken });
+
+    expect(res).to.have.property('statusCode', 401);
+  });
+
+  it(`the token still belongs to ${seed.wallet.name}`, async () => {
+    const res = await request(server)
+      .get(`/tokens/${seed.token.id}`)
+      .set('Authorization', `Bearer ${bearerToken}`);
+
+    expect(res).to.have.property('statusCode', 200);
+    expect(res.body).to.have.property('id').eq(seed.token.id);
+  });
+});

--- a/__tests__/actiontoken-transfer.spec.js
+++ b/__tests__/actiontoken-transfer.spec.js
@@ -1,0 +1,65 @@
+
+ // Integration test: issue an action token, redeem it from a second wallet
+ // Auth: Bearer is the wallet's keycloak_account_id (JWTService.verify stubbed by mocks.js)
+require('dotenv').config();
+const request = require('supertest');
+const { expect } = require('chai');
+const chai = require('chai');
+const server = require('../server/app');
+const seed = require('./seed');
+
+chai.use(require('chai-uuid'));
+
+describe('Issue and redeem an action token', () => {
+  let bearerToken;
+  let bearerTokenB;
+  let actionToken;
+
+  before(async () => {
+    await seed.clear();
+    await seed.seed();
+    bearerToken = seed.wallet.keycloak_account_id;
+    bearerTokenB = seed.walletB.keycloak_account_id;
+  });
+
+  it(`${seed.wallet.name} issues an action token for its token`, async () => {
+    const res = await request(server)
+      .post('/action-tokens')
+      .set('Authorization', `Bearer ${bearerToken}`)
+      .send({ recipient_email: 'samwel@example.com', tokens: [seed.token.id] });
+
+    expect(res).to.have.property('statusCode', 201);
+    expect(res.body).to.have.property('action_token').that.match(/\S+/);
+    expect(res.body).to.have.property('token_count', 1);
+    expect(res.body).to.have.property('expires_at');
+    actionToken = res.body.action_token;
+  });
+
+  it(`${seed.walletB.name} redeems the action token and the transfer completes`, async () => {
+    const res = await request(server)
+      .post('/action-tokens/redeem')
+      .set('Authorization', `Bearer ${bearerTokenB}`)
+      .send({ action_token: actionToken });
+
+    expect(res).to.have.property('statusCode', 200);
+    expect(res.body).to.have.property('state', 'completed');
+    expect(res.body.parameters.tokens).to.include(seed.token.id);
+  });
+
+  it(`the token now belongs to ${seed.walletB.name}`, async () => {
+    const res = await request(server)
+      .get(`/tokens/${seed.token.id}`)
+      .set('Authorization', `Bearer ${bearerTokenB}`);
+
+    expect(res).to.have.property('statusCode', 200);
+    expect(res.body).to.have.property('id').eq(seed.token.id);
+  });
+
+  it(`the token no longer belongs to ${seed.wallet.name}`, async () => {
+    const res = await request(server)
+      .get(`/tokens/${seed.token.id}`)
+      .set('Authorization', `Bearer ${bearerToken}`);
+
+    expect(res).to.have.property('statusCode', 403);
+  });
+});

--- a/server/handlers/actionTokenHandler/index.js
+++ b/server/handlers/actionTokenHandler/index.js
@@ -1,0 +1,32 @@
+const ActionTokenService = require('../../services/ActionTokenService');
+const {
+  actionTokenGenerateSchema,
+  actionTokenRedeemSchema,
+} = require('./schemas');
+
+const actionTokenGenerate = async (req, res) => {
+  const validatedBody = await actionTokenGenerateSchema.validateAsync(
+    req.body,
+    { abortEarly: false },
+  );
+  const { wallet_id } = req;
+
+  const actionTokenService = new ActionTokenService();
+  const result = await actionTokenService.generate(validatedBody, wallet_id);
+
+  res.status(201).json(result);
+};
+
+const actionTokenRedeem = async (req, res) => {
+  const validatedBody = await actionTokenRedeemSchema.validateAsync(req.body, {
+    abortEarly: false,
+  });
+  const { wallet_id } = req;
+
+  const actionTokenService = new ActionTokenService();
+  const result = await actionTokenService.redeem(validatedBody, wallet_id);
+
+  res.status(200).json(result);
+};
+
+module.exports = { actionTokenGenerate, actionTokenRedeem };

--- a/server/handlers/actionTokenHandler/schemas.js
+++ b/server/handlers/actionTokenHandler/schemas.js
@@ -1,0 +1,29 @@
+const Joi = require('joi');
+
+
+ // Issue: either explicit token ids or a bundle size, plus the recipient email
+ // Mirrors the tokens|bundle shape of the transfer POST schema
+
+const actionTokenGenerateSchema = Joi.alternatives().conditional(
+  Joi.object({
+    tokens: Joi.any().required(),
+  }).unknown(),
+  {
+    then: Joi.object({
+      recipient_email: Joi.string().email().required(),
+      tokens: Joi.array().items(Joi.string().uuid()).required().unique(),
+    }),
+    otherwise: Joi.object({
+      recipient_email: Joi.string().email().required(),
+      bundle: Joi.object({
+        bundle_size: Joi.number().integer().min(1).max(10000).required(),
+      }).required(),
+    }),
+  },
+);
+
+const actionTokenRedeemSchema = Joi.object({
+  action_token: Joi.string().required(),
+});
+
+module.exports = { actionTokenGenerateSchema, actionTokenRedeemSchema };

--- a/server/models/Transfer.js
+++ b/server/models/Transfer.js
@@ -228,6 +228,54 @@ class Transfer {
     return expect.fail();
   }
 
+  
+   // Complete a transfer authorized by a redeemed action token
+   // Signed token replaces trust/control checks; tokens validated up front (all-or-nothing)
+  async transferActionToken(originatorWalletId, sender, receiver, tokens) {
+    tokens.forEach((token) => {
+      if (!Token.belongsTo(token, sender.id)) {
+        throw new HttpError(
+          409,
+          `The token ${token.id} is no longer owned by the sender wallet`,
+        );
+      }
+      if (!Token.beAbleToTransfer(token)) {
+        throw new HttpError(
+          409,
+          `The token ${token.id} cannot be transferred--for example, it is part of another pending transfer`,
+        );
+      }
+      if (token.claim) {
+        throw new HttpError(
+          409,
+          `The token ${token.id} is claimed, cannot be transferred`,
+        );
+      }
+    });
+
+    const transfer = await this.create({
+      originator_wallet_id: originatorWalletId,
+      source_wallet_id: sender.id,
+      destination_wallet_id: receiver.id,
+      state: TransferEnums.STATE.completed,
+      parameters: {
+        tokens: tokens.map((token) => token.id),
+      },
+      claim: false,
+    });
+
+    await this._token.completeTransfer(
+      tokens,
+      {
+        ...transfer,
+        source_wallet_id: sender.id,
+        destination_wallet_id: receiver.id,
+      },
+      false,
+    );
+    return transfer;
+  }
+
   async transferBundle(
     walletLoginId,
     sender,

--- a/server/routes/actionTokenRouter.js
+++ b/server/routes/actionTokenRouter.js
@@ -1,0 +1,15 @@
+const express = require('express');
+
+const router = express.Router();
+const routerWrapper = express.Router();
+const { handlerWrapper, verifyJWTHandler } = require('../utils/utils');
+const {
+  actionTokenGenerate,
+  actionTokenRedeem,
+} = require('../handlers/actionTokenHandler');
+
+router.post('/', handlerWrapper(actionTokenGenerate));
+router.post('/redeem', handlerWrapper(actionTokenRedeem));
+
+routerWrapper.use('/action-tokens', verifyJWTHandler, router);
+module.exports = routerWrapper;

--- a/server/routes/index.js
+++ b/server/routes/index.js
@@ -4,4 +4,5 @@ module.exports = [
   require('./trustRouter'),
   require('./walletRouter'),
   require('./eventRouter'),
+  require('./actionTokenRouter'),
 ];

--- a/server/services/ActionTokenService.js
+++ b/server/services/ActionTokenService.js
@@ -1,0 +1,107 @@
+/**
+ * Action tokens for "send token by email": a stateless, signed, expiring
+ * token authorizing a future transfer
+*/
+const jwt = require('jsonwebtoken');
+const HttpError = require('../utils/HttpError');
+const TokenService = require('./TokenService');
+const TransferService = require('./TransferService');
+
+const ACTION_TOKEN_TYPE = 'send-token';
+const ACTION_TOKEN_TTL = process.env.ACTION_TOKEN_TTL || '7d';
+const ACTION_TOKEN_SECRET =
+  process.env.ACTION_TOKEN_SECRET || 'action-token-dev-secret';
+
+class ActionTokenService {
+  constructor() {
+    this._tokenService = new TokenService();
+    this._transferService = new TransferService();
+  }
+
+  /** 
+   * options can override signing options 
+  */
+  static signActionToken(payload, options = {}) {
+    return jwt.sign(
+      { ...payload, action: ACTION_TOKEN_TYPE },
+      ACTION_TOKEN_SECRET,
+      {
+        issuer: 'greenstand',
+        algorithm: 'HS256',
+        expiresIn: ACTION_TOKEN_TTL,
+        ...options,
+      },
+    );
+  }
+
+  // Verify signature, issuer, expiry, and action type; any failure is a 401
+  static verifyActionToken(token) {
+    if (!token) {
+      throw new HttpError(401, 'ERROR: ActionToken, no token supplied');
+    }
+    let decoded;
+    try {
+      decoded = jwt.verify(token, ACTION_TOKEN_SECRET, {
+        issuer: 'greenstand',
+        algorithms: ['HS256'],
+      });
+    } catch (err) {
+      if (err.name === 'TokenExpiredError') {
+        throw new HttpError(401, 'ERROR: ActionToken expired');
+      }
+      throw new HttpError(401, 'ERROR: ActionToken not verified');
+    }
+    if (decoded.action !== ACTION_TOKEN_TYPE) {
+      throw new HttpError(401, 'ERROR: ActionToken, invalid action type');
+    }
+    return decoded;
+  }
+
+  async generate({ recipient_email, tokens, bundle }, walletLoginId) {
+    let tokenIds;
+
+    if (tokens) {
+      const resolved = await Promise.all(
+        tokens.map((id) => this._tokenService.getById({ id, walletLoginId })),
+      );
+      tokenIds = resolved.map((token) => token.id);
+    } else {
+      const resolved = await this._tokenService.getTokens({
+        limit: bundle.bundle_size,
+        offset: 0,
+        walletLoginId,
+      });
+      if (resolved.length < bundle.bundle_size) {
+        throw new HttpError(
+          409,
+          `Wallet does not have ${bundle.bundle_size} tokens available`,
+        );
+      }
+      tokenIds = resolved.map((token) => token.id);
+    }
+
+    const actionToken = ActionTokenService.signActionToken({
+      sub: recipient_email,
+      sender_wallet_id: walletLoginId,
+      token_ids: tokenIds,
+    });
+
+    const { exp } = ActionTokenService.verifyActionToken(actionToken);
+    return {
+      action_token: actionToken,
+      expires_at: new Date(exp * 1000).toISOString(),
+      token_count: tokenIds.length,
+    };
+  }
+
+  async redeem({ action_token }, walletLoginId) {
+    const payload = ActionTokenService.verifyActionToken(action_token);
+    return this._transferService.redeemActionToken({
+      senderWalletId: payload.sender_wallet_id,
+      receiverWalletId: walletLoginId,
+      tokenIds: payload.token_ids,
+    });
+  }
+}
+
+module.exports = ActionTokenService;

--- a/server/services/TransferService.js
+++ b/server/services/TransferService.js
@@ -439,6 +439,55 @@ class TransferService {
     }
   }
 
+
+   // Transfer the tokens promised by a redeemed action token 
+  async redeemActionToken({ senderWalletId, receiverWalletId, tokenIds }) {
+    try {
+      await this._session.beginTransaction();
+
+      const senderWallet = await this._walletService.getById(senderWalletId);
+      const receiverWallet =
+        await this._walletService.getById(receiverWalletId);
+
+      const tokenService = new TokenService();
+      const tokens = await Promise.all(
+        tokenIds.map((id) => tokenService.getById({ id }, true)),
+      );
+
+      const result = await this._transfer.transferActionToken(
+        receiverWallet.id,
+        senderWallet,
+        receiverWallet,
+        tokens,
+      );
+
+      const payload = {
+        walletSender: senderWallet.name,
+        walletReceiver: receiverWallet.name,
+        tokenTransferred: tokenIds,
+      };
+
+      await this._eventService.logEvent({
+        wallet_id: senderWallet.id,
+        type: EventEnums.TRANSFER.transfer_completed,
+        payload,
+      });
+      await this._eventService.logEvent({
+        wallet_id: receiverWallet.id,
+        type: EventEnums.TRANSFER.transfer_completed,
+        payload,
+      });
+
+      await this._session.commitTransaction();
+      return result;
+    } catch (e) {
+      if (this._session.isTransactionInProgress()) {
+        await this._session.rollbackTransaction();
+      }
+      throw e;
+    }
+  }
+
   async getTransferById(transferId, walletLoginId) {
     const transfer = await this._transfer.getById({
       transferId,


### PR DESCRIPTION
## Description
Implements #457 on the keycloak branch: send tokens to a future account holder via a signed, expiring JWT action token.

Two endpoints, both behind the existing Keycloak JWT auth (`verifyJWTHandler`):
- `POST /action-tokens` : issue a token for `tokens: [ids]` or `bundle: { bundle_size }`
- `POST /action-tokens/redeem` : verify and execute the transfer

**Issue(s) addressed**
- Resolves #457

**What kind of change(s) does this PR introduce?**

- [x] Enhancement
- [ ] Bug fix
- [ ] Refactor

**Please check if the PR fulfils these requirements**

- [x] The commit message follows our guidelines
- [x] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)

## Issue

**What is the current behavior?**
Token transfers require both the sender and receiver wallets to already exist;
there is no way to send tokens to someone who has not registered yet.

**What is the new behavior?**
- Issue a signed action token (HS256, issuer `greenstand`, default 7-day TTL)
  describing the sender wallet and the token ids to transfer.
- Redeem it from any authenticated wallet: the signed token is the
  authorization, so the named tokens move sender to redeemer as a single,
  atomic `completed` transfer.
- Expired, tampered, wrong-issuer, or wrong-type tokens are denied `401`.
- If the sender no longer owns a listed token at redeem time, it fails `409`
  with no partial transfer (accepted-risk case; no escrow in v1).
- Integration tests cover the issue→redeem happy path and expiry denial.

## Breaking change

**Does this PR introduce a breaking change?**
No.


## Other useful information
Scope intentionally limited per the issue discussion:
- No escrow / pending-hold of tokens at issue time (owner keeps custody)
- Bearer model: possession of the token authorizes redemption; the recipient
  email (`sub`) is informational
- No email delivery, one-time-use, or revocation in this version
